### PR TITLE
Add blog section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,8 @@
+title: Brett Adams
+description: Notes on software engineering, co-op life, and things I'm building.
+url: "https://brettadams0.github.io"
+markdown: kramdown
+permalink: /blog/:year/:month/:day/:title/
+exclude:
+  - scss
+  - README.md

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{% if page.title %}{{ page.title }} | {% endif %}Brett Adams</title>
+
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Alfa+Slab+One&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Alegreya:wght@400;600;700;800;900&display=swap">
+
+    <!-- Font Awesome icons -->
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
+      integrity="sha512-iBBXm8fW90+nuLcSKlbmrPcLa0OT92xO1BIsZ+ywDWZCvqsWgccV3gFoRBv0z+8dLJgyAHIhR35VZc2oM/gI1w=="
+      crossorigin="anonymous"
+    />
+
+    <!-- Animation library styles -->
+    <link rel="stylesheet" href="https://unpkg.com/aos@next/dist/aos.css" />
+
+    <link rel="stylesheet" type="text/css" href="/dist/css/styles.css" />
+    <link rel="stylesheet" type="text/css" href="/assets/css/blog.css" />
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-EBYB5MK388"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-EBYB5MK388');
+    </script>
+  </head>
+  <body>
+    <header id="blog-header">
+      <nav id="nav">
+        <div class="container nav-container">
+          <a href="/index.html" id="logo">
+            <img src="/dist/img/logo.png" alt="logo">
+          </a>
+          <ul class="hide-for-mobile nav-links flex">
+            <li><a href="/index.html#projects" class="link"><i class="fas fa-code"></i> Projects</a></li>
+            <li><a href="/index.html#skills" class="link"><i class="fas fa-tools"></i> Skills</a></li>
+            <li><a href="/index.html#education" class="link"><i class="fas fa-user-graduate"></i> Education</a></li>
+            <li><a href="/blog/" class="link"><i class="fas fa-pen"></i> Blog</a></li>
+            <li><a href="/index.html#contact" class="link"><i class="fas fa-envelope"></i> Contact</a></li>
+          </ul>
+        </div>
+        <div class="mobile-menu hide-for-desktop">
+          <div class="container">
+            <div class="mobile-menu-links">
+              <ul class="flex">
+                <li><a href="/index.html#projects" class="link blue-hover">Projects</a></li>
+                <li><a href="/index.html#skills" class="link blue-hover">Skills</a></li>
+                <li><a href="/index.html#education" class="link blue-hover">Education</a></li>
+                <li><a href="/blog/" class="link blue-hover">Blog</a></li>
+                <li><a href="/index.html#contact" class="link blue-hover">Contact</a></li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </nav>
+    </header>
+
+    <main class="blog-main container">
+      {{ content }}
+    </main>
+
+    <footer id="footer" class="footer">
+      <div class="container">
+        <div class="footer-flex">
+          <img src="/dist/img/logo.png" alt="logo" id="logo-footer">
+          <div class="footer-icon-links">
+            <a href="https://github.com/brettadams0" target="_blank"><i class="fab fa-github fa-2x"></i></a>
+            <a href="https://www.linkedin.com/in/BrettA/" target="_blank"><i class="fab fa-linkedin fa-2x"></i></a>
+            <a href="mailto:adamsbrett00@gmail.com" target="_blank"><i class="fas fa-envelope fa-2x"></i></a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <a id="backToTopBtn" class="btn-blue">
+      <i class="fa fa-chevron-up"></i>
+    </a>
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script>
+      const backToTopBtn = $("#backToTopBtn");
+      $(window).scroll(function () {
+        if ($(window).scrollTop() > 300) {
+          backToTopBtn.addClass("show");
+        } else {
+          backToTopBtn.removeClass("show");
+        }
+      });
+      backToTopBtn.on("click", function (e) {
+        e.preventDefault();
+        $("html, body").animate({ scrollTop: 0 }, "300");
+      });
+    </script>
+
+    <!-- AOS Animations -->
+    <script src="https://unpkg.com/aos@next/dist/aos.js"></script>
+    <script>
+      AOS.init();
+    </script>
+  </body>
+</html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,11 @@
+---
+layout: default
+---
+<article class="blog-post" data-aos="fade-up">
+  <a href="/blog/" class="back-link">&larr; Back to Blog</a>
+  <h1 class="main-font">{{ page.title }}</h1>
+  <p class="post-date">{{ page.date | date: "%B %-d, %Y" }}</p>
+  <div class="post-content">
+    {{ content }}
+  </div>
+</article>

--- a/_posts/2026-07-26-blog-is-live.md
+++ b/_posts/2026-07-26-blog-is-live.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: "This blog is live"
+date: 2026-07-26
+---
+
+This is the first post on the blog section of my portfolio site — mostly just confirming the plumbing works.
+
+Going forward I'll use this space for notes on what I'm building, things I learn during my co-op at Geotab, and progress on personal projects.
+
+More soon.

--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -1,0 +1,124 @@
+/* Blog-specific styles — layered on top of dist/css/styles.css, does not modify it */
+
+#blog-header {
+  min-height: auto;
+  padding: 1.5rem 0 0.5rem;
+}
+
+.blog-main {
+  min-height: 60vh;
+  padding-top: 2rem;
+  padding-bottom: 4rem;
+  color: #dcdcdc;
+}
+
+.blog-hero {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.blog-hero h1 {
+  font-size: clamp(2rem, 5vw, 3rem);
+}
+
+.blog-hero p {
+  color: #dcdcdc;
+  margin-top: 0.5rem;
+}
+
+.post-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.post-card {
+  display: block;
+  padding: 1.5rem;
+  border: 1px solid #2e3031;
+  border-radius: 6px;
+  background: #1f2224;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.post-card:hover {
+  border-color: #3b82f6;
+  transform: translateY(-2px);
+}
+
+.post-card h2 {
+  color: white;
+  margin-bottom: 0.4rem;
+}
+
+.post-date {
+  color: #3b82f6;
+  font-size: 0.85rem;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  margin-bottom: 0.75rem;
+}
+
+.post-excerpt {
+  color: #dcdcdc;
+}
+
+.blog-post {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.blog-post .back-link {
+  display: inline-block;
+  color: #3b82f6;
+  margin-bottom: 1.5rem;
+}
+
+.blog-post h1 {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  margin-bottom: 0.5rem;
+}
+
+.post-content {
+  margin-top: 2rem;
+  line-height: 1.8;
+}
+
+.post-content p {
+  margin-bottom: 1.25rem;
+}
+
+.post-content a {
+  color: #3b82f6;
+  text-decoration: underline;
+}
+
+.post-content h2,
+.post-content h3 {
+  margin: 2rem 0 1rem;
+  color: white;
+}
+
+.post-content pre {
+  background: #1f2224;
+  padding: 1rem;
+  border-radius: 6px;
+  overflow-x: auto;
+  margin-bottom: 1.25rem;
+}
+
+.post-content code {
+  background: #1f2224;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+.post-content blockquote {
+  border-left: 3px solid #3b82f6;
+  padding-left: 1rem;
+  color: #dcdcdc;
+  margin: 1.5rem 0;
+}

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,21 @@
+---
+layout: default
+title: Blog
+permalink: /blog/
+---
+<div class="blog-hero" data-aos="fade-in">
+  <h1 class="main-font">Brett's <span class="text-blue main-font">Blog</span></h1>
+  <p>Notes on software engineering, the Geotab co-op, and things I'm building on the side.</p>
+</div>
+
+<div class="post-list">
+  {% for post in site.posts %}
+  <a class="post-card" href="{{ post.url }}" data-aos="fade-up">
+    <h2>{{ post.title }}</h2>
+    <p class="post-date">{{ post.date | date: "%B %-d, %Y" }}</p>
+    {% if post.excerpt %}<p class="post-excerpt">{{ post.excerpt | strip_html | truncatewords: 30 }}</p>{% endif %}
+  </a>
+  {% else %}
+  <p>No posts yet — check back soon.</p>
+  {% endfor %}
+</div>

--- a/index.html
+++ b/index.html
@@ -69,13 +69,18 @@
                 >
               </li>
               <li>
+                <a href="blog/" class="link"
+                  ><i class="fas fa-pen"></i> Blog</a
+                >
+              </li>
+              <li>
                 <a href="#contact" class="link"
                   ><i class="fas fa-envelope"></i> Contact</a
                 >
               </li>
             </ul>
           </div>
-  
+
           <div class="mobile-menu hide-for-desktop">
             <div class="container">
               <div class="mobile-menu-links">
@@ -93,6 +98,11 @@
                   <li>
                     <a href="#education" class="link blue-hover"
                       >Education</a
+                    >
+                  </li>
+                  <li>
+                    <a href="blog/" class="link blue-hover"
+                      >Blog</a
                     >
                   </li>
                   <li>


### PR DESCRIPTION
## Summary
- Adds a `/blog/` section using GitHub Pages' built-in Jekyll support (no build tooling needed beyond what Pages already runs)
- New layouts (`_layouts/default.html`, `_layouts/post.html`) match the existing site's fonts, blue/dark-grey palette, and nav/footer markup
- New `assets/css/blog.css` — additive, doesn't touch `dist/css/styles.css` or the scss source
- One starter post (`_posts/2026-07-26-blog-is-live.md`) so the listing page isn't empty
- "Blog" link added to the homepage nav (desktop + mobile)

## Notes
- No Ruby/Jekyll installed locally to test-build this before pushing — GitHub Pages builds Jekyll server-side on merge to `main`. If the build fails, Pages keeps serving the last successful build (site won't go down), so worst case is "new content doesn't show yet" not "site breaks."
- To add a new post going forward: drop a file in `_posts/` named `YYYY-MM-DD-title.md` with `layout: post`, `title`, and `date` in the front matter.

## Test plan
- [ ] Merge and check the Pages build succeeds (repo's Actions/Pages deployment tab)
- [ ] Visit https://brettadams0.github.io/blog/ and confirm it renders with the right styling
- [ ] Click through to the starter post and confirm the layout looks right
- [ ] Check homepage nav "Blog" link works on both desktop and mobile widths