### PR TITLE
Update experience/positioning from LinkedIn

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,18 +6,18 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Brett Adams | Software Engineer</title>
+    <title>Brett Adams | Data Analyst & Software Engineer</title>
 
     <!-- SEO / social preview -->
-    <meta name="description" content="Brett Adams — Software Engineering co-op student at the University of Windsor, currently at Geotab. Portfolio of projects, work experience, and writing." />
+    <meta name="description" content="Brett Adams — Data Analyst Intern at Geotab (BigQuery, Airflow, SQL), CS Software Engineering student at the University of Windsor. Portfolio of experience, projects, and writing." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://brettadams0.github.io/" />
-    <meta property="og:title" content="Brett Adams | Software Engineer" />
-    <meta property="og:description" content="Software Engineering co-op student at the University of Windsor, currently at Geotab. Portfolio of projects, work experience, and writing." />
+    <meta property="og:title" content="Brett Adams | Data Analyst & Software Engineer" />
+    <meta property="og:description" content="Data Analyst Intern at Geotab (BigQuery, Airflow, SQL), CS Software Engineering student at the University of Windsor. Portfolio of experience, projects, and writing." />
     <meta property="og:image" content="https://brettadams0.github.io/dist/img/logo.png" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Brett Adams | Software Engineer" />
-    <meta name="twitter:description" content="Software Engineering co-op student at the University of Windsor, currently at Geotab." />
+    <meta name="twitter:title" content="Brett Adams | Data Analyst & Software Engineer" />
+    <meta name="twitter:description" content="Data Analyst Intern at Geotab (BigQuery, Airflow, SQL), CS Software Engineering student at the University of Windsor." />
     <meta name="twitter:image" content="https://brettadams0.github.io/dist/img/logo.png" />
 
     <!-- Google Fonts -->
@@ -150,7 +150,7 @@
               Hi, I'm <span class="main-font text-blue">Brett</span>
             </h1>
             <p class="student" id="student">
-              Software Engineering student at <a href="https://www.uwindsor.ca" class="blue-link-underline" target="_blank">the University of Windsor</a>, currently on co-op at <a href="https://www.geotab.com" class="blue-link-underline" target="_blank">Geotab</a>.
+              Data Analyst Intern at <a href="https://www.geotab.com" class="blue-link-underline" target="_blank">Geotab</a> — BigQuery, Airflow, SQL — and a Software Engineering student at <a href="https://www.uwindsor.ca" class="blue-link-underline" target="_blank">the University of Windsor</a>.
             </p>
             <div class="hero-btns">
               <a href="#projects" class="btn-blue"><i class="fas fa-code"></i> Projects</a>
@@ -194,36 +194,54 @@
         <div class="timeline">
           <div class="timeline-item" data-aos="fade-up">
             <div class="timeline-header">
-              <h3>Software Engineering Co-op</h3>
+              <h3>Data Analyst Intern</h3>
               <span class="timeline-date">May 2026 - Present</span>
             </div>
-            <p class="timeline-company">Geotab &middot; Oakville, ON</p>
-          </div>
-
-          <div class="timeline-item" data-aos="fade-up">
-            <div class="timeline-header">
-              <h3>Developer, Summer Student</h3>
-              <span class="timeline-date">Apr 2024 - Sep 2024</span>
-            </div>
-            <p class="timeline-company">CIMCO Refrigeration &middot; Burlington, ON</p>
+            <p class="timeline-company">Geotab &middot; Oakville, ON &middot; Hybrid</p>
             <ul class="timeline-bullets">
-              <li>Developed and maintained Flask web applications integrating real-time APIs for NHL arenas, including a comprehensive web interface and thermal imagery support system.</li>
-              <li>Designed and delivered hands-on Python training for 20+ employees, building the team's technical capabilities.</li>
-              <li>Engineered a Python automation tool that streamlined data collection for CAG engineers, improving accuracy and operational efficiency.</li>
-              <li>Diagnosed and resolved critical bugs in legacy Python and Visual Basic codebases.</li>
+              <li>Maintain and debug Apache Airflow DAGs in Google Cloud Composer for production SalesOps data pipelines.</li>
+              <li>Write and deploy production BigQuery SQL for Revenue Operations tables, including device status, database dimensions, and accounts master datasets.</li>
+              <li>Manage the full GitLab CI/CD workflow, guiding changes from branch development through staging validation to production deployment.</li>
+              <li>Execute live table migrations against strict infrastructure deadlines while collaborating across cross-functional data owners.</li>
             </ul>
           </div>
 
           <div class="timeline-item" data-aos="fade-up">
             <div class="timeline-header">
-              <h3>Digital Solutions, Summer Student</h3>
+              <h3>Data Management Associate, Co-op</h3>
+              <span class="timeline-date">Jan 2025 - Aug 2025</span>
+            </div>
+            <p class="timeline-company">Ontario Ministry of Transportation &middot; St. Catharines, ON &middot; Hybrid</p>
+            <ul class="timeline-bullets">
+              <li>Engineered enterprise Power BI dashboards integrating large-scale datasets from Azure Databricks and SQL, replacing manual reporting processes across multiple business units.</li>
+              <li>Developed complex SQL queries and VBA automation scripts to modernize legacy workflows, reducing manual processing time from hours to minutes.</li>
+              <li>Spearheaded the technical rollout of the internal Data Broker Tool, driving cross-team onboarding and establishing a standardized data vocabulary.</li>
+            </ul>
+          </div>
+
+          <div class="timeline-item" data-aos="fade-up">
+            <div class="timeline-header">
+              <h3>Digital Solutions, Co-op</h3>
+              <span class="timeline-date">Apr 2024 - Sep 2024</span>
+            </div>
+            <p class="timeline-company">CIMCO Refrigeration &middot; Burlington, ON &middot; Hybrid</p>
+            <ul class="timeline-bullets">
+              <li>Built and shipped production Flask web applications delivering real-time analytics to NHL arena operations teams.</li>
+              <li>Developed a specialized thermal imagery visualization tool used by arena technicians to monitor refrigeration systems during live game environments.</li>
+              <li>Automated engineering data collection workflows, significantly reducing manual data entry across controller monitoring systems.</li>
+            </ul>
+          </div>
+
+          <div class="timeline-item" data-aos="fade-up">
+            <div class="timeline-header">
+              <h3>Digital Solutions</h3>
               <span class="timeline-date">Apr 2023 - Sep 2023</span>
             </div>
-            <p class="timeline-company">CIMCO Refrigeration &middot; Burlington, ON</p>
+            <p class="timeline-company">CIMCO Refrigeration &middot; Burlington, ON &middot; Hybrid</p>
             <ul class="timeline-bullets">
-              <li>Built Microsoft Power Platform tools to improve operational efficiency and user experience.</li>
-              <li>Worked with SharePoint to automate and streamline internal workflows.</li>
-              <li>Collaborated with cross-functional teams to identify and solve technical challenges.</li>
+              <li>Built and deployed Microsoft Power Platform tools adopted across multiple departments to automate high-frequency manual workflows.</li>
+              <li>Implemented SharePoint-based document routing and approval automation, cutting cross-department turnaround times.</li>
+              <li>Delivered technical solutions iteratively through close, cross-functional collaboration with engineering, operations, and IT stakeholders.</li>
             </ul>
           </div>
         </div>
@@ -341,6 +359,9 @@
           <li><span class="iconify" data-icon="vscode-icons:file-type-css" data-inline="false" data-width="90px" data-height="90px"></span><span>CSS</span></li>
           <li><span class="iconify" data-icon="logos:git-icon" data-inline="false" data-width="90px" data-height="90px"></span><span>Git</span></li>
           <li><span class="iconify" data-icon="logos:mysql" data-inline="false" data-width="90px" data-height="90px"></span><span>MySQL</span></li>
+          <li><span class="iconify" data-icon="logos:google-bigquery" data-inline="false" data-width="90px" data-height="90px"></span><span>BigQuery</span></li>
+          <li><span class="iconify" data-icon="logos:apache-airflow" data-inline="false" data-width="90px" data-height="90px"></span><span>Airflow</span></li>
+          <li><span class="iconify" data-icon="logos:databricks-icon" data-inline="false" data-width="90px" data-height="90px"></span><span>Databricks</span></li>
           <li><span class="iconify" data-icon="skill-icons:flask-light" data-inline="false" data-width="90px" data-height="90px"></span><span>Flask</span></li>
           <li><span class="iconify" data-icon="flat-color-icons:linux" data-inline="false" data-width="90px" data-height="90px"></span><span>Linux</span></li>
           <li><span class="iconify" data-icon="logos:c" data-inline="false" data-width="90px" data-height="90px"></span><span>C</span></li>


### PR DESCRIPTION
## Summary
You sent over your actual LinkedIn data, which is more current and accurate than what I had (I'd placeholder'd the Geotab role as generic "Software Engineering Co-op" with no bullets, and didn't know about the Ontario MOT co-op at all).

- Geotab role corrected to real title (**Data Analyst Intern**) with real bullets — Airflow/Cloud Composer, BigQuery SQL, GitLab CI/CD, live table migrations
- Added the Ontario Ministry of Transportation co-op (Power BI + Azure Databricks, SQL/VBA automation, Data Broker Tool rollout) — wasn't on the site before
- Refreshed both CIMCO entries to match current LinkedIn wording
- Hero copy, page `<title>`, and meta/OG tags updated — you're positioning as data analyst/data engineering now (BigQuery/Airflow/SQL), not generic "software engineer," so the site should say that
- Added BigQuery, Airflow, Databricks to skills

## Test plan
- [ ] Merge and confirm Pages build succeeds
- [ ] Check all 4 experience entries render correctly, especially on mobile
- [ ] Confirm hero/title change reads well