### PR TITLE
Fix mobile horizontal overflow

### DIFF
--- a/dist/css/styles.css
+++ b/dist/css/styles.css
@@ -415,6 +415,8 @@ header nav .mobile-menu .container {
 header nav .mobile-menu .container .mobile-menu-links ul {
   justify-content: center;
   align-items: center;
+  flex-wrap: wrap;
+  row-gap: 0.5rem;
   list-style-type: none;
 }
 header nav .mobile-menu .container .mobile-menu-links ul li {
@@ -469,6 +471,18 @@ header .hero .hero-btns {
   white-space: nowrap;
   text-align: center;
   margin-top: 1rem;
+}
+@media screen and (max-width: 500px) {
+  header .hero .hero-btns {
+    white-space: normal;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem;
+  }
+  header .hero .hero-btns .mx-1 {
+    margin: 0;
+  }
 }
 header .socials {
   position: absolute;
@@ -1143,5 +1157,17 @@ header .seperator-skew svg .fill-white {
   .experience .timeline-header {
     flex-direction: column;
     align-items: flex-start;
+  }
+  .experience .timeline-item {
+    padding: 1.25rem 1.25rem;
+  }
+}
+
+@media screen and (max-width: 500px) {
+  .project-left.icon-tile {
+    min-height: 200px;
+  }
+  .project-left.icon-tile i {
+    font-size: 3.5rem;
   }
 }

--- a/scss/_experience.scss
+++ b/scss/_experience.scss
@@ -144,5 +144,18 @@
       flex-direction: column;
       align-items: flex-start;
     }
+    .timeline-item {
+      padding: 1.25rem 1.25rem;
+    }
+  }
+}
+
+@media screen and (max-width: 500px) {
+  .project-left.icon-tile {
+    min-height: 200px;
+
+    i {
+      font-size: 3.5rem;
+    }
   }
 }

--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -74,6 +74,8 @@ header {
           ul {
             justify-content: center;
             align-items: center;
+            flex-wrap: wrap;
+            row-gap: 0.5rem;
             list-style-type: none;
             li {
               margin: 0rem 1rem;
@@ -138,6 +140,18 @@ header {
       white-space: nowrap;
       text-align: center;
       margin-top: 1rem;
+
+      @media screen and (max-width: 500px) {
+        white-space: normal;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 0.75rem;
+
+        .mx-1 {
+          margin: 0;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
"Make it more mobile-friendly" — didn't want to guess, so I actually drove a real headless browser against the live site at a 390px (iPhone-class) viewport and measured it.

**Confirmed the actual bug, not a hunch:** `document.documentElement.scrollWidth` was 440px against a 390px viewport. The two culprits, found by checking which elements crossed the viewport edge:
- Mobile nav (6 items now, up from 4 before the recent redesign) — no wrap, so "Experience" got clipped on the left and "Contact" clipped on the right
- Hero buttons (3 now, up from 2) — `white-space: nowrap` meant the "Github" button overflowed off-screen entirely

## Fix
- Mobile nav: `flex-wrap: wrap` so it flows to a second row instead of overflowing
- Hero buttons: wrap onto multiple rows below 500px instead of forcing one line
- Minor: tightened icon-tile project card height and experience timeline padding on narrow screens for better use of space

## Verification
Re-tested locally after the fix: `scrollWidth` now equals `clientWidth` exactly at 390px — zero horizontal overflow. Screenshotted the full page at that width scrolling through every section (Experience, Projects, Skills, Education, Contact) — all render cleanly, nothing else clipped.

## Test plan
- [ ] Merge, confirm Pages build succeeds
- [ ] Load the live site on an actual phone and confirm nav + hero buttons look right