### PR TITLE
Fix broken BigQuery/Airflow/Databricks icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,9 +359,9 @@
           <li><span class="iconify" data-icon="vscode-icons:file-type-css" data-inline="false" data-width="90px" data-height="90px"></span><span>CSS</span></li>
           <li><span class="iconify" data-icon="logos:git-icon" data-inline="false" data-width="90px" data-height="90px"></span><span>Git</span></li>
           <li><span class="iconify" data-icon="logos:mysql" data-inline="false" data-width="90px" data-height="90px"></span><span>MySQL</span></li>
-          <li><span class="iconify" data-icon="logos:google-bigquery" data-inline="false" data-width="90px" data-height="90px"></span><span>BigQuery</span></li>
-          <li><span class="iconify" data-icon="logos:apache-airflow" data-inline="false" data-width="90px" data-height="90px"></span><span>Airflow</span></li>
-          <li><span class="iconify" data-icon="logos:databricks-icon" data-inline="false" data-width="90px" data-height="90px"></span><span>Databricks</span></li>
+          <li><span class="iconify" data-icon="gcp:bigquery" data-inline="false" data-width="90px" data-height="90px"></span><span>BigQuery</span></li>
+          <li><span class="iconify" data-icon="logos:airflow-icon" data-inline="false" data-width="90px" data-height="90px"></span><span>Airflow</span></li>
+          <li><span class="iconify" data-icon="vscode-icons:file-type-databricks" data-inline="false" data-width="90px" data-height="90px"></span><span>Databricks</span></li>
           <li><span class="iconify" data-icon="skill-icons:flask-light" data-inline="false" data-width="90px" data-height="90px"></span><span>Flask</span></li>
           <li><span class="iconify" data-icon="flat-color-icons:linux" data-inline="false" data-width="90px" data-height="90px"></span><span>Linux</span></li>
           <li><span class="iconify" data-icon="logos:c" data-inline="false" data-width="90px" data-height="90px"></span><span>C</span></li>


### PR DESCRIPTION
## Summary
The icon names I used when I added these three skills were guesses that turned out wrong — none existed in Iconify's icon sets, so they rendered blank/broken.

This time I verified against Iconify's real search API instead of guessing, then confirmed each one actually renders as a populated, brand-colored SVG (screenshotted locally) before pushing:

- BigQuery → `gcp:bigquery`
- Airflow → `logos:airflow-icon`
- Databricks → `vscode-icons:file-type-databricks`

## Test plan
- [ ] Merge, confirm Pages build succeeds
- [ ] Check the Skills section shows all three with real logos, matching the rest