### PR TITLE
Phase C: technical/SEO/accessibility fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You can view the live website [here.](https://brettadams0.github.io/)
 - HTML5
 - CSS3
 - JavaScript
-- jQuery
+- Jekyll (blog, hosted at `/blog/`)
 - Particles.js
 - GSAP animations
 - AOS Animations

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,21 @@
-title: Brett Adams
-description: Notes on software engineering, co-op life, and things I'm building.
+title: Brett Adams | Data Analyst & Software Engineer
+description: >-
+  Data Analyst Intern at Geotab (BigQuery, Airflow, SQL), CS Software
+  Engineering student at the University of Windsor. Portfolio of experience,
+  projects, and writing.
 url: "https://brettadams0.github.io"
+logo: /dist/img/logo.png
+author:
+  name: Brett Adams
 markdown: kramdown
 permalink: /blog/:year/:month/:day/:title/
+plugins:
+  - jekyll-seo-tag
+  - jekyll-sitemap
+social:
+  links:
+    - https://github.com/brettadams0
+    - https://www.linkedin.com/in/bretta/
 exclude:
   - scss
   - README.md

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{% if page.title %}{{ page.title }} | {% endif %}Brett Adams</title>
+    <link rel="icon" type="image/png" href="/dist/img/logo.png" />
+    {% seo %}
 
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -22,7 +23,12 @@
     />
 
     <!-- Animation library styles -->
-    <link rel="stylesheet" href="https://unpkg.com/aos@next/dist/aos.css" />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/aos@3.0.0-beta.6/dist/aos.css"
+      integrity="sha384-6oNXtl81GMcKAnWPPXinWlPskKUQ0NGG1/XeyMfC5RgCJKPc03w0rHVt1jyoJLf0"
+      crossorigin="anonymous"
+    />
 
     <link rel="stylesheet" type="text/css" href="/dist/css/styles.css" />
     <link rel="stylesheet" type="text/css" href="/assets/css/blog.css" />
@@ -41,7 +47,7 @@
       <nav id="nav">
         <div class="container nav-container">
           <a href="/index.html" id="logo">
-            <img src="/dist/img/logo.png" alt="logo">
+            <img src="/dist/img/logo.png" alt="logo" width="1563" height="560">
           </a>
           <ul class="hide-for-mobile nav-links flex">
             <li><a href="/index.html#projects" class="link"><i class="fas fa-code"></i> Projects</a></li>
@@ -74,40 +80,55 @@
     <footer id="footer" class="footer">
       <div class="container">
         <div class="footer-flex">
-          <img src="/dist/img/logo.png" alt="logo" id="logo-footer">
+          <img src="/dist/img/logo.png" alt="logo" id="logo-footer" width="1563" height="560">
           <div class="footer-icon-links">
-            <a href="https://github.com/brettadams0" target="_blank"><i class="fab fa-github fa-2x"></i></a>
-            <a href="https://www.linkedin.com/in/BrettA/" target="_blank"><i class="fab fa-linkedin fa-2x"></i></a>
-            <a href="mailto:adamsbrett00@gmail.com" target="_blank"><i class="fas fa-envelope fa-2x"></i></a>
+            <a href="https://github.com/brettadams0" aria-label="GitHub" target="_blank"><i class="fab fa-github fa-2x"></i></a>
+            <a href="https://www.linkedin.com/in/BrettA/" aria-label="LinkedIn" target="_blank"><i class="fab fa-linkedin fa-2x"></i></a>
+            <a href="mailto:adamsbrett00@gmail.com" aria-label="Email" target="_blank"><i class="fas fa-envelope fa-2x"></i></a>
           </div>
         </div>
       </div>
     </footer>
 
-    <a id="backToTopBtn" class="btn-blue">
+    <button id="backToTopBtn" class="btn-blue" aria-label="Back to top" type="button">
       <i class="fa fa-chevron-up"></i>
-    </a>
+    </button>
 
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script>
-      const backToTopBtn = $("#backToTopBtn");
-      $(window).scroll(function () {
-        if ($(window).scrollTop() > 300) {
-          backToTopBtn.addClass("show");
+      const backToTopBtn = document.getElementById("backToTopBtn");
+      window.addEventListener("scroll", function () {
+        if (window.scrollY > 300) {
+          backToTopBtn.classList.add("show");
         } else {
-          backToTopBtn.removeClass("show");
+          backToTopBtn.classList.remove("show");
         }
       });
-      backToTopBtn.on("click", function (e) {
+      backToTopBtn.addEventListener("click", function (e) {
         e.preventDefault();
-        $("html, body").animate({ scrollTop: 0 }, "300");
+        var prefersReducedMotion = window.matchMedia(
+          "(prefers-reduced-motion: reduce)"
+        ).matches;
+        window.scrollTo({
+          // "auto" defers to CSS `scroll-behavior`, which is smooth site-wide —
+          // "instant" is required to actually bypass that for reduced-motion users.
+          top: 0,
+          behavior: prefersReducedMotion ? "instant" : "smooth",
+        });
       });
     </script>
 
     <!-- AOS Animations -->
-    <script src="https://unpkg.com/aos@next/dist/aos.js"></script>
+    <script
+      src="https://unpkg.com/aos@3.0.0-beta.6/dist/aos.js"
+      integrity="sha384-ZGo5k5ISlEzWLoXyt+lnvKt9j03Z7GkxXh14zLqVy098XJhcdKHjL8pQYVMI8WiH"
+      crossorigin="anonymous"
+    ></script>
     <script>
-      AOS.init();
+      AOS.init({
+        disable: function () {
+          return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        }
+      });
     </script>
   </body>
 </html>

--- a/dist/css/styles.css
+++ b/dist/css/styles.css
@@ -2,6 +2,12 @@ html {
   scroll-behavior: smooth;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -52,7 +58,7 @@ a {
 }
 
 .text-blue {
-  color: #3b82f6;
+  color: #2563eb;
 }
 
 .text-white {
@@ -68,7 +74,7 @@ a {
 }
 
 .bg-blue {
-  background-color: #3b82f6;
+  background-color: #2563eb;
 }
 
 .bg-dark-grey {
@@ -90,17 +96,17 @@ a {
 
 .btn-blue {
   color: white;
-  background-color: #3b82f6;
-  border: 2px solid #3b82f6;
+  background-color: #2563eb;
+  border: 2px solid #2563eb;
 }
 .btn-dark {
   color: white;
   background-color: #181a1b;
 }
 .btn-blue-outline {
-  color: #3b82f6;
+  color: #2563eb;
   background-color: transparent;
-  border: 2px solid #3b82f6;
+  border: 2px solid #2563eb;
 }
 .btn-blue:hover {
   transition: all 0.3s ease;
@@ -109,7 +115,7 @@ a {
 }
 .btn-blue-outline:hover {
   color: white;
-  background-color: #3b82f6;
+  background-color: #2563eb;
 }
 .btn-small {
   padding: 0.5rem 1rem;
@@ -136,13 +142,13 @@ a {
 }
 
 .btn-email {
-  --primary: #3b82f6;
+  --primary: #2563eb;
   --primary-dark: #0455d8;
   --primary-darkest: #013281;
   --shadow: rgba(0, 0, 0, 0.3);
   --text: #fff;
   --text-opacity: 1;
-  --success: #3b82f6;
+  --success: #2563eb;
   --success-x: -12;
   --success-stroke: 14;
   --success-opacity: 0;
@@ -154,7 +160,7 @@ a {
   --plane-x: 0;
   --plane-y: 0;
   --plane-opacity: 1;
-  --trails: rgba(59, 130, 246, 0.15);
+  --trails: rgba(37, 99, 235, 0.15);
   --trails-stroke: 57;
   --left-wing-background: var(--primary);
   --left-wing-first-x: 0;
@@ -399,7 +405,7 @@ header nav .nav-container .nav-links .link::after {
   height: 2px;
   top: 3px;
   margin: auto;
-  background: #3b82f6;
+  background: #2563eb;
   transition: width 0.3s ease;
 }
 header nav .nav-container .nav-links .link:hover::after {
@@ -430,7 +436,7 @@ header nav .mobile-menu .container .mobile-menu-links ul .link::after {
   height: 2px;
   top: 3px;
   margin: auto;
-  background: #3b82f6;
+  background: #2563eb;
   transition: width 0.3s ease;
 }
 header nav .mobile-menu .container .mobile-menu-links ul .link:hover::after {
@@ -537,8 +543,8 @@ header .scroll-btn-container div a span {
   display: block;
   height: 20px;
   width: 20px;
-  border-bottom: 2px solid #3b82f6;
-  border-right: 2px solid #3b82f6;
+  border-bottom: 2px solid #2563eb;
+  border-right: 2px solid #2563eb;
   transform: rotate(45deg);
   margin: -20px 0;
   animation: animate 2s infinite;
@@ -654,14 +660,14 @@ header .seperator-skew svg .fill-white {
 .projects .project-row .project-right h3 {
   font-size: 1.25rem;
 }
+.projects .project-row .project-right > p.text-grey {
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+}
 .projects .project-row .project-right .tech-stack-list {
   display: flex;
   flex-wrap: wrap;
   list-style-type: none;
-  margin-top: 1rem;
-}
-.projects .project-row .project-right .tech-stack-list p {
-  margin-right: 1rem;
 }
 .projects .project-row .project-right .tech-stack-list li {
   margin-right: 20px;
@@ -753,6 +759,7 @@ header .seperator-skew svg .fill-white {
 .education .container .education-card .education-card-column .card-column-large > * {
   margin: 0.25rem 0;
 }
+.education .container .education-card .education-card-column .card-column-large h3,
 .education .container .education-card .education-card-column .card-column-large h4 {
   font-weight: normal;
 }
@@ -890,7 +897,7 @@ header .seperator-skew svg .fill-white {
 }
 .contact .card-container .card i {
   font-size: 3.5rem;
-  color: #3b82f6;
+  color: #2563eb;
   margin-bottom: 1rem;
   transition: 0.4s;
 }
@@ -997,15 +1004,15 @@ header .seperator-skew svg .fill-white {
   transition: 0.3s;
 }
 .footer .footer-flex .top-scroll-button:hover {
-  color: #3b82f6;
-  border: 3px solid #3b82f6;
+  color: #2563eb;
+  border: 3px solid #2563eb;
 }
 .footer .footer-flex .footer-icon-links a {
   margin-left: 2rem;
   transition: 0.3s;
 }
 .footer .footer-flex .footer-icon-links a:hover {
-  color: #3b82f6;
+  color: #2563eb;
 }
 .footer .footer-flex .footer-icon-links a i {
   transition: 0.3s;
@@ -1054,7 +1061,7 @@ header .seperator-skew svg .fill-white {
   border-radius: 3px;
   padding: 1.75rem 2rem;
   margin-bottom: 1.5rem;
-  border-left: 3px solid #3b82f6;
+  border-left: 3px solid #2563eb;
 }
 .experience .timeline-item:last-child {
   margin-bottom: 0;
@@ -1071,7 +1078,7 @@ header .seperator-skew svg .fill-white {
   color: black;
 }
 .experience .timeline-date {
-  color: #3b82f6;
+  color: #2563eb;
   font-size: 0.85rem;
   letter-spacing: 1px;
   text-transform: uppercase;
@@ -1101,7 +1108,7 @@ header .seperator-skew svg .fill-white {
 }
 .project-left.icon-tile i {
   font-size: 5rem;
-  color: #3b82f6;
+  color: #2563eb;
 }
 
 .home-blog-teaser {
@@ -1142,7 +1149,7 @@ header .seperator-skew svg .fill-white {
   margin-bottom: 0.4rem;
 }
 .home-blog-teaser .home-blog-date {
-  color: #3b82f6;
+  color: #2563eb;
   font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 1px;

--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -44,6 +44,22 @@ function ajax(method, url, data, success, error) {
         if (!button.classList.contains("active")) {
           button.classList.add("active");
 
+          if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+            // Skip the paper-plane keyframe animation entirely; jump
+            // straight to the success state and reset shortly after.
+            gsap.set(button, {
+              "--text-opacity": 0,
+              "--success-opacity": 1,
+              "--success-x": 0,
+              "--success-stroke": 0,
+            });
+            setTimeout(() => {
+              button.removeAttribute("style");
+              button.classList.remove("active");
+            }, 1800);
+            return;
+          }
+
           gsap.to(button, {
             keyframes: [
               {
@@ -176,17 +192,25 @@ function ajax(method, url, data, success, error) {
 
 // Back to top arrow button
 
-const backToTopBtn = $("#backToTopBtn");
+const backToTopBtn = document.getElementById("backToTopBtn");
 
-$(window).scroll(function () {
-  if ($(window).scrollTop() > 300) {
-    backToTopBtn.addClass("show");
+window.addEventListener("scroll", function () {
+  if (window.scrollY > 300) {
+    backToTopBtn.classList.add("show");
   } else {
-    backToTopBtn.removeClass("show");
+    backToTopBtn.classList.remove("show");
   }
 });
 
-backToTopBtn.on("click", function (e) {
+backToTopBtn.addEventListener("click", function (e) {
   e.preventDefault();
-  $("html, body").animate({ scrollTop: 0 }, "300");
+  var prefersReducedMotion = window.matchMedia(
+    "(prefers-reduced-motion: reduce)"
+  ).matches;
+  window.scrollTo({
+    // "auto" defers to CSS `scroll-behavior`, which is smooth site-wide —
+    // "instant" is required to actually bypass that for reduced-motion users.
+    top: 0,
+    behavior: prefersReducedMotion ? "instant" : "smooth",
+  });
 });

--- a/index.html
+++ b/index.html
@@ -6,19 +6,34 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Brett Adams | Data Analyst & Software Engineer</title>
+    <link rel="icon" type="image/png" href="dist/img/logo.png" />
+    {% seo %}
 
-    <!-- SEO / social preview -->
-    <meta name="description" content="Brett Adams — Data Analyst Intern at Geotab (BigQuery, Airflow, SQL), CS Software Engineering student at the University of Windsor. Portfolio of experience, projects, and writing." />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://brettadams0.github.io/" />
-    <meta property="og:title" content="Brett Adams | Data Analyst & Software Engineer" />
-    <meta property="og:description" content="Data Analyst Intern at Geotab (BigQuery, Airflow, SQL), CS Software Engineering student at the University of Windsor. Portfolio of experience, projects, and writing." />
-    <meta property="og:image" content="https://brettadams0.github.io/dist/img/logo.png" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Brett Adams | Data Analyst & Software Engineer" />
-    <meta name="twitter:description" content="Data Analyst Intern at Geotab (BigQuery, Airflow, SQL), CS Software Engineering student at the University of Windsor." />
-    <meta name="twitter:image" content="https://brettadams0.github.io/dist/img/logo.png" />
+    <!-- Additional structured data (jekyll-seo-tag above covers title/meta/OG/Twitter/WebSite JSON-LD) -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ProfilePage",
+      "mainEntity": {
+        "@type": "Person",
+        "name": "Brett Adams",
+        "jobTitle": "Data Analyst Intern",
+        "worksFor": {
+          "@type": "Organization",
+          "name": "Geotab"
+        },
+        "alumniOf": {
+          "@type": "CollegeOrUniversity",
+          "name": "University of Windsor"
+        },
+        "url": "https://brettadams0.github.io/",
+        "sameAs": [
+          "https://github.com/brettadams0",
+          "https://www.linkedin.com/in/bretta/"
+        ]
+      }
+    }
+    </script>
 
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -40,11 +55,20 @@
       crossorigin="anonymous"
     />
 
-    <!-- Animation library styles -->    
-    <link rel="stylesheet" href="https://unpkg.com/aos@next/dist/aos.css" />
+    <!-- Animation library styles -->
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/aos@3.0.0-beta.6/dist/aos.css"
+      integrity="sha384-6oNXtl81GMcKAnWPPXinWlPskKUQ0NGG1/XeyMfC5RgCJKPc03w0rHVt1jyoJLf0"
+      crossorigin="anonymous"
+    />
 
     <!-- Iconify Icons -->
-    <script src="https://code.iconify.design/1/1.0.7/iconify.min.js"></script>
+    <script
+      src="https://code.iconify.design/1/1.0.7/iconify.min.js"
+      integrity="sha384-jQq64HqdQD5xg0PPkpkCOW3x8Nsfx5UT1qWOpoJxLYy6Ef+5i+8xPoAj/I3B+ZMm"
+      crossorigin="anonymous"
+    ></script>
     
     <link rel="stylesheet" type="text/css" href="dist/css/styles.css" />
 
@@ -65,7 +89,7 @@
         <nav id="nav" data-aos="fade-in">
           <div class="container nav-container">
             <a href="index.html" id="logo">
-              <img src="dist/img/logo.png" alt="logo">
+              <img src="dist/img/logo.png" alt="logo" width="1563" height="560">
             </a>
             <ul class="hide-for-mobile nav-links flex">
               <li>
@@ -260,8 +284,8 @@
           </div>
           <div class="project-right">
             <h3>NHL Arena Web Interface</h3>
+            <p class="text-grey"><b>Made with: </b></p>
             <ul class="tech-stack-list">
-              <p class="text-grey"><b>Made with: </b></p>
               <li><span class="iconify" data-icon="logos:python" data-inline="false"></span></li>
               <li><span class="iconify" data-icon="skill-icons:flask-light" data-inline="false" data-width="30" data-height="30"></span></li>
               <li><span class="iconify" data-icon="logos:javascript" data-inline="false"></span></li>
@@ -279,8 +303,8 @@
           </div>
           <div class="project-right">
             <h3>TechNest</h3>
+            <p class="text-grey"><b>Made with: </b></p>
             <ul class="tech-stack-list">
-              <p class="text-grey"><b>Made with: </b></p>
               <li><span class="iconify" data-icon="logos:php" data-inline="false"></span></li>
               <li><span class="iconify" data-icon="logos:mysql" data-inline="false"></span></li>
               <li><span class="iconify" data-icon="vscode-icons:file-type-html" data-inline="false"></span></li>
@@ -301,8 +325,8 @@
           </div>
           <div class="project-right">
             <h3>MazeFinder - Genetic Algorithm</h3>
+            <p class="text-grey"><b>Made with: </b></p>
             <ul class="tech-stack-list">
-              <p class="text-grey"><b>Made with: </b></p>
               <li><span class="iconify" data-icon="logos:c" data-inline="false"></span></li>
             </ul>
             <p>A C++ application that solves 20x20 mazes using genetic algorithms, with a custom thread pool for parallel genome fitness evaluation and dynamic mutation/crossover strategies to refine optimal paths.</p>
@@ -321,8 +345,8 @@
           </div>
           <div class="project-right">
             <h3>Spotify Stats Viewer</h3>
+            <p class="text-grey"><b>Made with: </b></p>
             <ul class="tech-stack-list">
-              <p class="text-grey"><b>Made with: </b></p>
               <li><span class="iconify" data-icon="logos:python" data-inline="false"></span></li>
               <li><span class="iconify" data-icon="vscode-icons:file-type-html" data-inline="false"></span></li>
               <li><span class="iconify" data-icon="skill-icons:flask-light" data-inline="false" data-width="30" data-height="30"></span></li>
@@ -387,12 +411,12 @@
         <div class="education-card" data-aos="zoom-in">
             <div class="education-card-column">
               <div class="card-column-image">
-                 <img src="dist/img/uw_logo.jpg" alt="University of Windsor Logo" style="max-width: 100%; max-height: 100%; height: auto; width: auto;">
+                 <img src="dist/img/uw_logo.jpg" alt="University of Windsor Logo" width="827" height="921" style="max-width: 100%; max-height: 100%; height: auto; width: auto;">
               </div>
 
               <div class="card-column-large">
-                <h4 class="education-year">2027</h4>
-                <h4><b>University of Windsor </b></h4>
+                <h3 class="education-year">2027</h3>
+                <h3><b>University of Windsor </b></h3>
                 <h4>Honours Computer Science with Software Engineering Specialization Co-op</h4>
               </div>
             </div>
@@ -478,16 +502,16 @@
     <footer id="footer" class="footer">
       <div class="container">
         <div class="footer-flex">
-          <img src="dist/img/logo.png" alt="logo" id="logo-footer">
+          <img src="dist/img/logo.png" alt="logo" id="logo-footer" width="1563" height="560">
 
           <div class="footer-icon-links">
-            <a href="https://github.com/brettadams0"
+            <a href="https://github.com/brettadams0" aria-label="GitHub"
               target="_blank"><i class="fab fa-github fa-2x"></i
             ></a>
-            <a href="https://www.linkedin.com/in/BrettA/"
+            <a href="https://www.linkedin.com/in/BrettA/" aria-label="LinkedIn"
               target="_blank"><i class="fab fa-linkedin fa-2x"></i
             ></a>
-            <a href="mailto:adamsbrett00@gmail.com"
+            <a href="mailto:adamsbrett00@gmail.com" aria-label="Email"
               target="_blank"><i class="fas fa-envelope fa-2x"></i
             ></a>
           </div>
@@ -496,41 +520,52 @@
     </footer>
 
     <!-- Back to top button in corner -->
-    <a id="backToTopBtn" class="btn-blue">
+    <button id="backToTopBtn" class="btn-blue" aria-label="Back to top" type="button">
       <i class="fa fa-chevron-up"></i>
-    </a>
-
-    <!-- jQuery -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-
-    <!-- Particles.js for hero section -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/particles.js/2.0.0/particles.min.js" integrity="sha512-Kef5sc7gfTacR7TZKelcrRs15ipf7+t+n7Zh6mKNJbmW+/RRdCW9nwfLn4YX0s2nO6Kv5Y2ChqgIakaC6PW09A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    </button>
 
     <!-- GSAP animations -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.6.1/gsap.min.js"></script>
 
     <script>
-      particlesJS.load('particles-js', './dist/particles.json', function(){
-        console.log("particles.json loaded...")
-      })
+      // Ambient/decorative motion (particle background) is skipped entirely
+      // for users who've asked the OS for reduced motion.
+      var prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-      particlesJS.load('skills', './dist/particles.json', function(){
-        console.log("particles.json loaded...")
-      })
-
-      particlesJS.load('footer', './dist/particles.json', function(){
-        console.log("particles.json loaded...")
-      })
-
-      particlesJS.load()
+      if (!prefersReducedMotion) {
+        var particlesScript = document.createElement('script');
+        particlesScript.src = 'https://cdnjs.cloudflare.com/ajax/libs/particles.js/2.0.0/particles.min.js';
+        particlesScript.integrity = 'sha512-Kef5sc7gfTacR7TZKelcrRs15ipf7+t+n7Zh6mKNJbmW+/RRdCW9nwfLn4YX0s2nO6Kv5Y2ChqgIakaC6PW09A==';
+        particlesScript.crossOrigin = 'anonymous';
+        particlesScript.referrerPolicy = 'no-referrer';
+        particlesScript.onload = function () {
+          ['particles-js', 'skills', 'footer'].forEach(function (id) {
+            particlesJS.load(id, './dist/particles.json', function () {
+              console.log('particles.json loaded...');
+            });
+          });
+        };
+        document.head.appendChild(particlesScript);
+      }
     </script>
 
     <script defer src="dist/js/app.js"></script>
 
     <!-- AOS Animations -->
-    <script src="https://unpkg.com/aos@next/dist/aos.js"></script>
+    <script
+      src="https://unpkg.com/aos@3.0.0-beta.6/dist/aos.js"
+      integrity="sha384-ZGo5k5ISlEzWLoXyt+lnvKt9j03Z7GkxXh14zLqVy098XJhcdKHjL8pQYVMI8WiH"
+      crossorigin="anonymous"
+    ></script>
     <script>
-      AOS.init();
+      // AOS's own `disable` option shows content immediately (no opacity:0
+      // hold) for reduced-motion users, instead of just skipping init and
+      // leaving [data-aos] elements invisible.
+      AOS.init({
+        disable: function () {
+          return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        }
+      });
     </script>
 
   </body>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://brettadams0.github.io/sitemap.xml

--- a/scss/_education.scss
+++ b/scss/_education.scss
@@ -45,6 +45,7 @@
             margin: 0.25rem 0;
           }
 
+          h3,
           h4 {
             font-weight: normal;
           }

--- a/scss/_globals.scss
+++ b/scss/_globals.scss
@@ -2,6 +2,12 @@ html {
   scroll-behavior: smooth;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 * {
   margin: 0;
   padding: 0;

--- a/scss/_projects.scss
+++ b/scss/_projects.scss
@@ -31,15 +31,19 @@
         font-size: 1.25rem;
       }
 
+      // The "Made with:" label is a sibling <p> before this list now
+      // (a <p> isn't valid as a direct child of <ul>), so it needs its
+      // own spacing instead of the flex-row margin it used to get as a
+      // list item.
+      > p.text-grey {
+        margin-top: 1rem;
+        margin-bottom: 0.5rem;
+      }
+
       .tech-stack-list {
         display: flex;
         flex-wrap: wrap;
         list-style-type: none;
-        margin-top: 1rem;
-
-        p {
-          margin-right: 1rem;
-        }
 
         li {
           margin-right: 20px;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,5 +1,9 @@
 $website-width: 1200px;
-$color-blue: #3b82f6;
+// #2563eb, not the original #3b82f6 — that shade fails WCAG AA contrast
+// (3.68:1) both as white-on-blue button text and as blue-on-white link text.
+// This shade clears 4.5:1 in both directions while staying in the same
+// Tailwind blue family (blue-500 -> blue-600).
+$color-blue: #2563eb;
 $dark-grey: #181a1b;
 $text-color: white;
 $text-light: #dcdcdc;


### PR DESCRIPTION
## Summary
Ran a real Lighthouse audit against the live site before touching anything — baseline: **Performance 61, Accessibility 81, Best Practices 92, SEO 100.** Fixed everything it flagged, plus the reduced-motion/SEO work from the plan.

**Reduced motion** — particles.js only loads when motion isn't reduced; AOS uses its `disable` option (not just skipping init, which would leave scroll-fade elements stuck invisible); GSAP's paper-plane submit animation jumps to its end state instead of animating. Found and fixed a real bug along the way: `scrollTo({behavior:'auto'})` actually defers to CSS `scroll-behavior: smooth` rather than forcing an instant scroll — needed `'instant'`. Also gated the site-wide CSS `scroll-behavior` itself, since it drives every anchor link, not just the back-to-top button.

**Dropped jQuery** entirely (only used for back-to-top) — rewrote both call sites in vanilla JS.

**SEO** — added `jekyll-seo-tag` + `jekyll-sitemap` (both on GitHub Pages' supported-plugin whitelist, no Gemfile needed) + `robots.txt`; replaced hand-maintained meta/OG/Twitter tags with `{% seo %}` to avoid duplicates; added `Person`/`ProfilePage` JSON-LD; fixed a favicon 404.

**Accessibility fixes the audit actually found** (not guessed):
- Brand blue (#3b82f6, Tailwind blue-500) failed contrast at 3.68:1 as both button text and link text — moved to blue-600 (#2563eb, 5.17:1), a single SCSS variable change
- Footer icon links and back-to-top had no accessible name; back-to-top was an `<a>` with no `href`, meaning it was **never keyboard-focusable at all** — converted to a real `<button>`
- Fixed heading order (Education card skipped h2→h4) and invalid markup (a `<p>` as a direct child of `<ul>` in every project card)
- Added explicit width/height to images missing them

**Security** — the `security-guidance` hook flagged mid-edit that AOS was loaded from a floating `@next` tag with no integrity hash. Pinned to the resolved version and added SRI to it and to Iconify (previously unpinned).

## Verification
Everything checked locally before push (Playwright/headless Chromium): reduced-motion behavior in both states, jQuery fully gone, JSON-LD validates, screenshots of every touched section. One caveat: `{% seo %}` and Jekyll front matter don't render in raw `file://` testing, so true SEO output can only be confirmed post-deploy — I'll re-run Lighthouse against the live site after merge to get real before/after numbers.

## Test plan
- [ ] Merge, confirm Pages build succeeds
- [ ] Re-run Lighthouse against live site, compare to baseline (61/81/92/100)
- [ ] Spot-check: reduced-motion OS setting actually disables particles/animations
- [ ] Tab through nav, back-to-top, and contact form to confirm keyboard nav works