### PR TITLE
Fix Lighthouse NO_LCP (dynamic script injection)

### DIFF
--- a/index.html
+++ b/index.html
@@ -527,25 +527,19 @@
     <!-- GSAP animations -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.6.1/gsap.min.js"></script>
 
-    <script>
-      // Ambient/decorative motion (particle background) is skipped entirely
-      // for users who've asked the OS for reduced motion.
-      var prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    <!-- Particles.js for hero section -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/particles.js/2.0.0/particles.min.js" integrity="sha512-Kef5sc7gfTacR7TZKelcrRs15ipf7+t+n7Zh6mKNJbmW+/RRdCW9nwfLn4YX0s2nO6Kv5Y2ChqgIakaC6PW09A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
-      if (!prefersReducedMotion) {
-        var particlesScript = document.createElement('script');
-        particlesScript.src = 'https://cdnjs.cloudflare.com/ajax/libs/particles.js/2.0.0/particles.min.js';
-        particlesScript.integrity = 'sha512-Kef5sc7gfTacR7TZKelcrRs15ipf7+t+n7Zh6mKNJbmW+/RRdCW9nwfLn4YX0s2nO6Kv5Y2ChqgIakaC6PW09A==';
-        particlesScript.crossOrigin = 'anonymous';
-        particlesScript.referrerPolicy = 'no-referrer';
-        particlesScript.onload = function () {
-          ['particles-js', 'skills', 'footer'].forEach(function (id) {
-            particlesJS.load(id, './dist/particles.json', function () {
-              console.log('particles.json loaded...');
-            });
+    <script>
+      // The script tag above always loads (keeps the dependency graph static
+      // and analyzable by tools like Lighthouse); only the actual canvas
+      // animation is skipped for users who've asked the OS for reduced motion.
+      if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        ['particles-js', 'skills', 'footer'].forEach(function (id) {
+          particlesJS.load(id, './dist/particles.json', function () {
+            console.log('particles.json loaded...');
           });
-        };
-        document.head.appendChild(particlesScript);
+        });
       }
     </script>
 


### PR DESCRIPTION
## Summary
Ran the Lighthouse comparison I said I would after Phase C merged. Accessibility jumped to 100 (from 81) and Best Practices improved — but Performance came back with a `null` score, three times, across two throttling methods.

Root cause: `NO_LCP`. Lighthouse's dependency-graph analysis couldn't resolve a Largest Contentful Paint candidate at all. I checked whether this was a real user-facing bug first — it isn't; direct DOM inspection on the live site confirms the hero content renders and reveals correctly for real visitors. The cause is specifically that I loaded particles.js through a dynamically-created `<script>` element (to gate it behind `prefers-reduced-motion`), which apparently breaks Lighthouse's static analysis even though real browsers handle it fine.

## Fix
Keep the `<script src="...">` tag static and always-loading (it's a small file either way), and only gate the actual `.load()` calls — the part that starts the canvas animation — behind the reduced-motion check. Same user-facing behavior, verified locally in both motion states, but now something tooling can actually see.

## Test plan
- [ ] Merge, confirm Pages build succeeds
- [ ] Re-run Lighthouse, confirm Performance produces a real score this time