### PR TITLE
Fix real root cause of NO_LCP

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
     <!-- HEADER -->
     <header id="header">
       <div id="particles-js">
-        <nav id="nav" data-aos="fade-in">
+        <nav id="nav">
           <div class="container nav-container">
             <a href="index.html" id="logo">
               <img src="dist/img/logo.png" alt="logo" width="1563" height="560">
@@ -168,7 +168,7 @@
 
         <!-- HERO -->
         <div class="hero">
-          <div data-aos="fade-up">
+          <div>
             <h1 class="h1">
               
               Hi, I'm <span class="main-font text-blue">Brett</span>
@@ -189,7 +189,7 @@
         </div>
 
         <!-- SOCIAL LINKS -->
-        <div class="socials" data-aos="fade-in"> 
+        <div class="socials">
           <ul>
             <li class="bg-blue"><a href="https://www.linkedin.com/in/bretta/"
               target="_blank"><span class="socials-text">LinkedIn</span> <i class="fab fa-linkedin fa-2x"></i


### PR DESCRIPTION
## Summary
The last fix (PR #8/9) was a wrong diagnosis — it didn't actually resolve anything, confirmed by re-testing after merge (still `NO_LCP`, three metrics affected together: LCP, TTI, TBT).

This time I isolated it properly instead of guessing again: used Lighthouse's `--blocked-url-patterns` flag to test hypotheses against the live site without needing a deploy per attempt. Blocking AOS entirely fixed it (LCP came back at 9.9s, matching the original 10.3s baseline almost exactly). But the blog page uses the *identical* `AOS.init({disable: ...})` call and measures fine — so it's not the disable option itself. The actual difference: the homepage's hero is `position: absolute` + `transform: translate(-50%,-50%)`, gated behind an AOS opacity fade. That specific combination is a known category of Chrome LCP-detection edge case.

## Fix
Removed `data-aos` from the three elements that are actually above the fold and visible on load (nav, hero, socials). Below-the-fold sections keep their scroll animations untouched — they were never LCP candidates anyway since they're not visible until scrolled into view.

Side benefit independent of the Lighthouse issue: primary hero content popping in via fade-in on every page load is debatable UX regardless — this means visitors see the page immediately.

## Test plan
- [ ] Merge, confirm Pages build succeeds
- [ ] Re-run Lighthouse, confirm Performance finally produces a real score
- [ ] Visual check that removing data-aos didn't make the hero's entrance feel abrupt/broken