### PR TITLE
Phase A: visual identity redesign

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,9 +10,7 @@
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Alfa+Slab+One&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Alegreya:wght@400;600;700;800;900&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap">
 
     <!-- Font Awesome icons -->
     <link

--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -9,7 +9,7 @@
   min-height: 60vh;
   padding-top: 2rem;
   padding-bottom: 4rem;
-  color: #dcdcdc;
+  color: #8695a7;
 }
 
 .blog-hero {
@@ -22,7 +22,7 @@
 }
 
 .blog-hero p {
-  color: #dcdcdc;
+  color: #8695a7;
   margin-top: 0.5rem;
 }
 
@@ -39,30 +39,31 @@
   padding: 1.5rem;
   border: 1px solid #2e3031;
   border-radius: 6px;
-  background: #1f2224;
+  background: #131a22;
   transition: border-color 0.2s ease, transform 0.2s ease;
 }
 
 .post-card:hover {
-  border-color: #3b82f6;
+  border-color: #ffb454;
   transform: translateY(-2px);
 }
 
 .post-card h2 {
-  color: white;
+  color: #e7ecf2;
   margin-bottom: 0.4rem;
 }
 
 .post-date {
-  color: #3b82f6;
-  font-size: 0.85rem;
-  letter-spacing: 1px;
+  color: #ffb454;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.8rem;
+  letter-spacing: 0.5px;
   text-transform: uppercase;
   margin-bottom: 0.75rem;
 }
 
 .post-excerpt {
-  color: #dcdcdc;
+  color: #8695a7;
 }
 
 .blog-post {
@@ -72,7 +73,7 @@
 
 .blog-post .back-link {
   display: inline-block;
-  color: #3b82f6;
+  color: #ffb454;
   margin-bottom: 1.5rem;
 }
 
@@ -91,34 +92,36 @@
 }
 
 .post-content a {
-  color: #3b82f6;
+  color: #ffb454;
   text-decoration: underline;
 }
 
 .post-content h2,
 .post-content h3 {
   margin: 2rem 0 1rem;
-  color: white;
+  color: #e7ecf2;
 }
 
 .post-content pre {
-  background: #1f2224;
+  background: #131a22;
   padding: 1rem;
   border-radius: 6px;
   overflow-x: auto;
   margin-bottom: 1.25rem;
+  font-family: "IBM Plex Mono", monospace;
 }
 
 .post-content code {
-  background: #1f2224;
+  background: #131a22;
   padding: 0.15rem 0.4rem;
   border-radius: 4px;
   font-size: 0.9em;
+  font-family: "IBM Plex Mono", monospace;
 }
 
 .post-content blockquote {
-  border-left: 3px solid #3b82f6;
+  border-left: 3px solid #ffb454;
   padding-left: 1rem;
-  color: #dcdcdc;
+  color: #8695a7;
   margin: 1.5rem 0;
 }

--- a/dist/css/styles.css
+++ b/dist/css/styles.css
@@ -7,30 +7,33 @@ html {
     scroll-behavior: auto;
   }
 }
-
 * {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
-  font-family: "Nunito", sans-serif;
+  font-family: "IBM Plex Sans", sans-serif;
 }
 
+body .noscroll {
+  overflow-x: hidden;
+}
 body {
   padding: 0;
   line-height: 1.5;
-  background: #181a1b;
-}
-body .noscroll {
-  overflow-x: hidden;
+  background: #0b0f14;
 }
 
 a {
   text-decoration: none;
-  color: white;
+  color: #e7ecf2;
 }
 
 .main-font {
-  font-family: "Nunito", sans-serif;
+  font-family: "IBM Plex Sans", sans-serif;
+}
+
+.mono-font {
+  font-family: "IBM Plex Mono", monospace;
 }
 
 .text-center {
@@ -58,7 +61,7 @@ a {
 }
 
 .text-blue {
-  color: #2563eb;
+  color: #996313;
 }
 
 .text-white {
@@ -74,7 +77,7 @@ a {
 }
 
 .bg-blue {
-  background-color: #2563eb;
+  background-color: #ffb454;
 }
 
 .bg-dark-grey {
@@ -95,27 +98,28 @@ a {
 }
 
 .btn-blue {
-  color: white;
-  background-color: #2563eb;
-  border: 2px solid #2563eb;
+  color: #0b0f14;
+  background-color: #ffb454;
+  border: 2px solid #ffb454;
 }
 .btn-dark {
-  color: white;
-  background-color: #181a1b;
+  color: #e7ecf2;
+  background-color: #0b0f14;
 }
 .btn-blue-outline {
-  color: #2563eb;
+  color: #996313;
   background-color: transparent;
-  border: 2px solid #2563eb;
+  border: 2px solid #996313;
 }
 .btn-blue:hover {
   transition: all 0.3s ease;
-  background: #0b63f3;
-  border: 2px solid #0b63f3;
+  background: rgb(100%, 61.8163054696%, 12.9411764706%);
+  border: 2px solid rgb(100%, 61.8163054696%, 12.9411764706%);
 }
 .btn-blue-outline:hover {
-  color: white;
-  background-color: #2563eb;
+  color: #0b0f14;
+  background-color: #ffb454;
+  border: 2px solid #ffb454;
 }
 .btn-small {
   padding: 0.5rem 1rem;
@@ -142,13 +146,13 @@ a {
 }
 
 .btn-email {
-  --primary: #2563eb;
-  --primary-dark: #0455d8;
-  --primary-darkest: #013281;
+  --primary: #ffb454;
+  --primary-dark: #d98d2b;
+  --primary-darkest: #93591a;
   --shadow: rgba(0, 0, 0, 0.3);
-  --text: #fff;
+  --text: #0b0f14;
   --text-opacity: 1;
-  --success: #2563eb;
+  --success: #996313;
   --success-x: -12;
   --success-stroke: 14;
   --success-opacity: 0;
@@ -160,7 +164,7 @@ a {
   --plane-x: 0;
   --plane-y: 0;
   --plane-opacity: 1;
-  --trails: rgba(37, 99, 235, 0.15);
+  --trails: rgba(255, 180, 84, 0.15);
   --trails-stroke: 57;
   --left-wing-background: var(--primary);
   --left-wing-first-x: 0;
@@ -325,8 +329,8 @@ a {
 }
 
 .blue-link-underline {
-  color: #0b63f3;
-  border-bottom: 1px solid #0b63f3;
+  color: #4fd6c4;
+  border-bottom: 1px solid #4fd6c4;
 }
 
 .flex {
@@ -350,25 +354,16 @@ a {
 }
 
 header {
-  background: #181a1b;
-  background-size: cover;
-  min-height: 80vh;
+  background: #0b0f14;
   position: relative;
-}
-header #particles-js {
-  height: 80vh;
-  position: relative;
-}
-header #particles-js canvas {
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  height: 100%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 4rem;
 }
 header nav {
   width: 100%;
+  padding-top: 1.5rem;
 }
 header nav .nav-container {
   position: relative;
@@ -394,8 +389,10 @@ header nav .nav-container .nav-links li {
 }
 header nav .nav-container .nav-links a {
   text-decoration: none;
-  letter-spacing: 2px;
-  color: white;
+  letter-spacing: 1px;
+  color: #e7ecf2;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.9rem;
 }
 header nav .nav-container .nav-links .link::after {
   content: "";
@@ -405,7 +402,7 @@ header nav .nav-container .nav-links .link::after {
   height: 2px;
   top: 3px;
   margin: auto;
-  background: #2563eb;
+  background: #ffb454;
   transition: width 0.3s ease;
 }
 header nav .nav-container .nav-links .link:hover::after {
@@ -428,6 +425,10 @@ header nav .mobile-menu .container .mobile-menu-links ul {
 header nav .mobile-menu .container .mobile-menu-links ul li {
   margin: 0rem 1rem;
 }
+header nav .mobile-menu .container .mobile-menu-links ul li a {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.9rem;
+}
 header nav .mobile-menu .container .mobile-menu-links ul .link::after {
   content: "";
   position: relative;
@@ -436,7 +437,7 @@ header nav .mobile-menu .container .mobile-menu-links ul .link::after {
   height: 2px;
   top: 3px;
   margin: auto;
-  background: #2563eb;
+  background: #ffb454;
   transition: width 0.3s ease;
 }
 header nav .mobile-menu .container .mobile-menu-links ul .link:hover::after {
@@ -444,34 +445,72 @@ header nav .mobile-menu .container .mobile-menu-links ul .link:hover::after {
 }
 header .hero {
   z-index: 5;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-}
-header .hero h1,
-header .hero p {
-  color: white;
-}
-header .hero h1,
-header .hero h2 span {
-  letter-spacing: 2px;
-  white-space: nowrap;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   text-align: center;
-  font-size: clamp(2rem, 5vw, 4rem);
-  font-weight: bold;
+  padding: 3rem 1.5rem 2rem;
 }
-header .hero p {
-  color: #dcdcdc;
-  line-height: 1.6;
-  font-size: clamp(1.25rem, 2vw, 1.5rem);
-  text-align: center;
+header .hero .hero-pipeline {
+  width: min(100%, 460px);
+  margin-bottom: 1.5rem;
+}
+header .hero .hero-pipeline svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  overflow: visible;
+}
+header .hero .hero-pipeline .edge path {
+  fill: none;
+  stroke: #8695a7;
+  stroke-width: 1.5;
+  stroke-dasharray: 6 6;
+  animation: pipeline-flow 1.4s linear infinite;
+}
+header .hero .hero-pipeline .node circle {
+  stroke: #0b0f14;
+  stroke-width: 2;
+}
+header .hero .hero-pipeline .node-endpoint circle {
+  fill: #ffb454;
+}
+header .hero .hero-pipeline .node-stage circle {
+  fill: #4fd6c4;
+  animation: pipeline-pulse 2.4s ease-in-out infinite;
+}
+header .hero .hero-pipeline .node-stage circle:nth-child(2) {
+  animation-delay: 0.25s;
+}
+header .hero .hero-pipeline .node-stage circle:nth-child(3) {
+  animation-delay: 0.5s;
+}
+@media (prefers-reduced-motion: reduce) {
+  header .hero .hero-pipeline .edge path,
+  header .hero .hero-pipeline .node-stage circle {
+    animation: none;
+  }
+}
+header .hero .hero-content {
   max-width: 800px;
-  margin: 0 auto;
-  padding: 0.5rem;
 }
-header .hero p .blue-link-underline {
-  color: #3783ff;
+header .hero h1,
+header .hero p {
+  color: #e7ecf2;
+}
+header .hero h1 {
+  letter-spacing: 1px;
+  font-size: clamp(2rem, 5vw, 4rem);
+  font-weight: 700;
+}
+header .hero p {
+  color: #8695a7;
+  line-height: 1.6;
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
+  margin: 0.75rem auto 0;
+  padding: 0.5rem;
 }
 header .hero .hero-btns {
   white-space: nowrap;
@@ -490,9 +529,16 @@ header .hero .hero-btns {
     margin: 0;
   }
 }
+header .hero .text-blue {
+  color: #ffb454;
+}
+header .hero .btn-blue-outline {
+  color: #ffb454;
+  border-color: #ffb454;
+}
 header .socials {
   position: absolute;
-  bottom: 40%;
+  bottom: 8%;
   left: -125px;
   z-index: 10;
 }
@@ -507,8 +553,10 @@ header .socials ul li {
   display: flex;
   justify-content: end;
   font-size: 1.5rem;
-  width: 100%;
   height: 100%;
+}
+header .socials ul li.bg-blue a {
+  color: #0b0f14;
 }
 header .socials ul li a {
   text-align: right;
@@ -522,51 +570,6 @@ header .socials ul li a i {
 }
 header .socials ul li:hover {
   transform: translateX(115px);
-}
-header .scroll-btn-container {
-  position: absolute;
-  width: 100%;
-  background: red;
-  bottom: 150px;
-}
-header .scroll-btn-container div {
-  display: flex;
-  justify-content: center;
-  width: 100%;
-}
-header .scroll-btn-container div a {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-}
-header .scroll-btn-container div a span {
-  display: block;
-  height: 20px;
-  width: 20px;
-  border-bottom: 2px solid #2563eb;
-  border-right: 2px solid #2563eb;
-  transform: rotate(45deg);
-  margin: -20px 0;
-  animation: animate 2s infinite;
-}
-header .scroll-btn-container div a span:nth-child(2) {
-  animation-delay: -0.2s;
-}
-header .scroll-btn-container div a span:nth-child(3) {
-  animation-delay: -0.4s;
-}
-@keyframes animate {
-  0% {
-    opacity: 0;
-    transform: rotate(45deg) translate(-20px, -20px);
-  }
-  50% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-    transform: rotate(45deg) translate(20px, 20px);
-  }
 }
 header .seperator-skew {
   position: absolute;
@@ -585,6 +588,19 @@ header .seperator-skew svg .fill-white {
   fill: white;
 }
 
+@keyframes pipeline-flow {
+  to {
+    stroke-dashoffset: -24;
+  }
+}
+@keyframes pipeline-pulse {
+  0%, 100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
 @media screen and (max-width: 999px) {
   header nav .container {
     padding-bottom: 0.75rem;
@@ -592,17 +608,11 @@ header .seperator-skew svg .fill-white {
   header nav .nav-container {
     justify-content: center;
   }
-  header .hero {
-    top: 55%;
-  }
   header .socials {
     display: none;
   }
 }
 @media screen and (max-width: 768px) {
-  .hero {
-    width: 90%;
-  }
   header nav .nav-container #logo img {
     width: 200px;
   }
@@ -614,19 +624,143 @@ header .seperator-skew svg .fill-white {
   header nav .mobile-menu .container .mobile-menu-links ul li {
     margin: 0 0.5rem;
   }
-  header .hero span {
-    max-width: 100%;
+}
+.experience {
+  background: white;
+  padding: 3rem 0 1rem;
+}
+.experience h2,
+.experience h2 span {
+  text-align: center;
+  font-weight: bold;
+}
+.experience .container {
+  max-width: 900px;
+}
+.experience .timeline {
+  margin-top: 3rem;
+}
+.experience .timeline-item {
+  box-shadow: 0 0.15rem 0.6rem rgba(43, 52, 56, 0.15);
+  border-radius: 3px;
+  padding: 1.75rem 2rem;
+  margin-bottom: 1.5rem;
+  border-left: 3px solid #996313;
+}
+.experience .timeline-item:last-child {
+  margin-bottom: 0;
+}
+.experience .timeline-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.experience .timeline-header h3 {
+  font-size: 1.15rem;
+  color: black;
+}
+.experience .timeline-date {
+  color: #996313;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.8rem;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.experience .timeline-company {
+  color: grey;
+  margin: 0.25rem 0 1rem;
+  font-weight: 600;
+}
+.experience .timeline-bullets {
+  padding-left: 1.25rem;
+  color: #333;
+}
+.experience .timeline-bullets li {
+  margin-bottom: 0.5rem;
+  line-height: 1.5;
+}
+
+.project-left.icon-tile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0b0f14;
+  border: 1px solid lightgray;
+  min-height: 300px;
+}
+.project-left.icon-tile i {
+  font-size: 5rem;
+  color: #ffb454;
+}
+
+.home-blog-teaser {
+  background: white;
+  padding: 1rem 0 3rem;
+}
+.home-blog-teaser h2,
+.home-blog-teaser h2 span {
+  text-align: center;
+  font-weight: bold;
+  margin-bottom: 2rem;
+}
+.home-blog-teaser .home-blog-list {
+  display: flex;
+  gap: 1.5rem;
+  max-width: 1000px;
+  margin: 0 auto;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.home-blog-teaser .home-blog-card {
+  flex: 1 1 260px;
+  max-width: 320px;
+  display: block;
+  padding: 1.25rem;
+  border: 1px solid #eee;
+  border-radius: 6px;
+  box-shadow: 0 0.15rem 0.6rem rgba(43, 52, 56, 0.1);
+  color: black;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.home-blog-teaser .home-blog-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 0.3rem 1rem rgba(43, 52, 56, 0.15);
+}
+.home-blog-teaser .home-blog-card h3 {
+  font-size: 1.05rem;
+  margin-bottom: 0.4rem;
+}
+.home-blog-teaser .home-blog-date {
+  color: #996313;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.home-blog-teaser .home-blog-cta {
+  display: block;
+  text-align: center;
+  margin-top: 2rem;
+}
+
+@media screen and (max-width: 600px) {
+  .experience .timeline-header {
+    flex-direction: column;
+    align-items: flex-start;
   }
-  header .hero p {
-    width: 100%;
+  .experience .timeline-item {
+    padding: 1.25rem 1.25rem;
   }
 }
-@media screen and (min-height: 900px) {
-  header {
-    min-height: 70vh;
+@media screen and (max-width: 500px) {
+  .project-left.icon-tile {
+    min-height: 200px;
   }
-  header #particles-js {
-    height: 70vh;
+  .project-left.icon-tile i {
+    font-size: 3.5rem;
   }
 }
 .projects {
@@ -769,6 +903,7 @@ header .seperator-skew svg .fill-white {
 .education .container .education-card .education-card-column .card-column-large hr {
   border: 0;
   border-top: 1px solid #eee;
+  margin-top: 40px;
 }
 
 .skills {
@@ -776,19 +911,14 @@ header .seperator-skew svg .fill-white {
   position: relative;
   overflow: hidden;
 }
-.skills canvas {
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  height: 100%;
-}
 .skills h2,
 .skills h2 span {
   text-align: center;
   margin-bottom: 3rem;
   font-weight: bold;
+}
+.skills .text-blue {
+  color: #ffb454;
 }
 .skills .container {
   padding: 6rem 0;
@@ -818,8 +948,9 @@ header .seperator-skew svg .fill-white {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  color: white;
-  font-size: 1rem;
+  color: #e7ecf2;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.9rem;
   margin: 1rem;
 }
 @media (max-width: 420px) {
@@ -897,7 +1028,7 @@ header .seperator-skew svg .fill-white {
 }
 .contact .card-container .card i {
   font-size: 3.5rem;
-  color: #2563eb;
+  color: #996313;
   margin-bottom: 1rem;
   transition: 0.4s;
 }
@@ -907,16 +1038,16 @@ header .seperator-skew svg .fill-white {
 .contact .card-container .card > * {
   margin: 0.5rem;
 }
+.contact form h2 {
+  text-align: center;
+  margin: 1.5rem 0;
+}
 .contact form {
   max-width: 600px;
   margin: 0 auto;
   border-radius: 3px;
   box-shadow: 0 0.15rem 0.6rem rgba(43, 52, 56, 0.15);
   padding: 2rem;
-}
-.contact form h2 {
-  text-align: center;
-  margin: 1.5rem 0;
 }
 .contact form .form-group input {
   margin: 0.75rem 0;
@@ -972,17 +1103,9 @@ header .seperator-skew svg .fill-white {
 }
 
 .footer {
-  background: #181a1b;
+  background: #0b0f14;
   padding: 1.5rem 0;
-  color: white;
-}
-.footer canvas {
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  height: 100%;
+  color: #e7ecf2;
 }
 .footer .footer-flex {
   display: flex;
@@ -1004,15 +1127,15 @@ header .seperator-skew svg .fill-white {
   transition: 0.3s;
 }
 .footer .footer-flex .top-scroll-button:hover {
-  color: #2563eb;
-  border: 3px solid #2563eb;
+  color: #ffb454;
+  border: 3px solid #ffb454;
 }
 .footer .footer-flex .footer-icon-links a {
   margin-left: 2rem;
   transition: 0.3s;
 }
 .footer .footer-flex .footer-icon-links a:hover {
-  color: #2563eb;
+  color: #ffb454;
 }
 .footer .footer-flex .footer-icon-links a i {
   transition: 0.3s;
@@ -1035,146 +1158,5 @@ header .seperator-skew svg .fill-white {
   }
   .footer .footer-flex .footer-icon-links a {
     margin: 0 1rem;
-  }
-}/*# sourceMappingURL=styles.css.map */
-
-/* --- Experience section, icon-tile project cards, homepage blog teaser --- */
-/* Compiled by hand from scss/_experience.scss (no local Sass build available) */
-
-.experience {
-  background: white;
-  padding: 3rem 0 1rem;
-}
-.experience h2,
-.experience h2 span {
-  text-align: center;
-  font-weight: bold;
-}
-.experience .container {
-  max-width: 900px;
-}
-.experience .timeline {
-  margin-top: 3rem;
-}
-.experience .timeline-item {
-  box-shadow: 0 0.15rem 0.6rem rgba(43, 52, 56, 0.15);
-  border-radius: 3px;
-  padding: 1.75rem 2rem;
-  margin-bottom: 1.5rem;
-  border-left: 3px solid #2563eb;
-}
-.experience .timeline-item:last-child {
-  margin-bottom: 0;
-}
-.experience .timeline-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-.experience .timeline-header h3 {
-  font-size: 1.15rem;
-  color: black;
-}
-.experience .timeline-date {
-  color: #2563eb;
-  font-size: 0.85rem;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  white-space: nowrap;
-}
-.experience .timeline-company {
-  color: grey;
-  margin: 0.25rem 0 1rem;
-  font-weight: 600;
-}
-.experience .timeline-bullets {
-  padding-left: 1.25rem;
-  color: #333;
-}
-.experience .timeline-bullets li {
-  margin-bottom: 0.5rem;
-  line-height: 1.5;
-}
-
-.project-left.icon-tile {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: #181a1b;
-  border: 1px solid lightgray;
-  min-height: 300px;
-}
-.project-left.icon-tile i {
-  font-size: 5rem;
-  color: #2563eb;
-}
-
-.home-blog-teaser {
-  background: white;
-  padding: 1rem 0 3rem;
-}
-.home-blog-teaser h2,
-.home-blog-teaser h2 span {
-  text-align: center;
-  font-weight: bold;
-  margin-bottom: 2rem;
-}
-.home-blog-teaser .home-blog-list {
-  display: flex;
-  gap: 1.5rem;
-  max-width: 1000px;
-  margin: 0 auto;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-.home-blog-teaser .home-blog-card {
-  flex: 1 1 260px;
-  max-width: 320px;
-  display: block;
-  padding: 1.25rem;
-  border: 1px solid #eee;
-  border-radius: 6px;
-  box-shadow: 0 0.15rem 0.6rem rgba(43, 52, 56, 0.1);
-  color: black;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-.home-blog-teaser .home-blog-card:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 0.3rem 1rem rgba(43, 52, 56, 0.15);
-}
-.home-blog-teaser .home-blog-card h3 {
-  font-size: 1.05rem;
-  margin-bottom: 0.4rem;
-}
-.home-blog-teaser .home-blog-date {
-  color: #2563eb;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-}
-.home-blog-teaser .home-blog-cta {
-  display: block;
-  text-align: center;
-  margin-top: 2rem;
-}
-
-@media screen and (max-width: 600px) {
-  .experience .timeline-header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-  .experience .timeline-item {
-    padding: 1.25rem 1.25rem;
-  }
-}
-
-@media screen and (max-width: 500px) {
-  .project-left.icon-tile {
-    min-height: 200px;
-  }
-  .project-left.icon-tile i {
-    font-size: 3.5rem;
   }
 }

--- a/index.html
+++ b/index.html
@@ -39,13 +39,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
-    <!-- Alfa Slab One font -->
-    <link href="https://fonts.googleapis.com/css2?family=Alfa+Slab+One&display=swap" rel="stylesheet">
-      
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
-
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Alegreya:wght@400;600;700;800;900&display=swap">
-    
+    <!-- IBM Plex Sans (headings/body) + IBM Plex Mono (technical/utility labels) -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap">
 
     <!-- Font Awesome icons -->
     <link
@@ -85,7 +80,6 @@
   <body>
     <!-- HEADER -->
     <header id="header">
-      <div id="particles-js">
         <nav id="nav">
           <div class="container nav-container">
             <a href="index.html" id="logo">
@@ -168,9 +162,29 @@
 
         <!-- HERO -->
         <div class="hero">
-          <div>
+          <div class="hero-pipeline" aria-hidden="true">
+            <svg viewBox="0 0 600 120" xmlns="http://www.w3.org/2000/svg">
+              <g class="edge">
+                <path d="M30,60 L300,20" />
+                <path d="M30,60 L300,60" />
+                <path d="M30,60 L300,100" />
+                <path d="M300,20 L570,60" />
+                <path d="M300,60 L570,60" />
+                <path d="M300,100 L570,60" />
+              </g>
+              <g class="node node-endpoint">
+                <circle cx="30" cy="60" r="7" />
+                <circle cx="570" cy="60" r="7" />
+              </g>
+              <g class="node node-stage">
+                <circle cx="300" cy="20" r="7" />
+                <circle cx="300" cy="60" r="7" />
+                <circle cx="300" cy="100" r="7" />
+              </g>
+            </svg>
+          </div>
+          <div class="hero-content">
             <h1 class="h1">
-              
               Hi, I'm <span class="main-font text-blue">Brett</span>
             </h1>
             <p class="student" id="student">
@@ -200,7 +214,6 @@
             <li class="bg-white"><a class="text-dark-grey" href="mailto:adamsbrett00@gmail.com"><span class="socials-text">Email</span><i class="fas fa-envelope fa-2x"></i></a></li>
           </ul>
         </div>
-      </div>
 
       <div class="seperator-skew">
         <svg x="0" y="0" viewBox="0 0 2560 100" preserveAspectRatio="none" version="1.1" xmlns="http://www.w3.org/2000/svg">
@@ -448,13 +461,13 @@
           <div class="card" data-aos="fade-in">
             <i class="fas fa-envelope"></i>
             <h3>Email</h3>
-            <a href="mailto:adamsbrett00@gmail.com" class="text-blue" target="_blank">adamsbrett00@gmail.com<a>
+            <a href="mailto:adamsbrett00@gmail.com" class="text-blue" target="_blank">adamsbrett00@gmail.com</a>
           </div>
           <div class="card" data-aos="fade-in" data-aos-delay="100">
             <i class="fab fa-github"></i
               >
             <h3>GitHub</h3>
-            <a href="https://github.com/brettadams0" class="text-blue" target="_blank">brettadams0<a>
+            <a href="https://github.com/brettadams0" class="text-blue" target="_blank">brettadams0</a>
           </div>
           <div class="card" data-aos="fade-in" data-aos-delay="200">
             <i class="fab fa-linkedin"></i>
@@ -526,22 +539,6 @@
 
     <!-- GSAP animations -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.6.1/gsap.min.js"></script>
-
-    <!-- Particles.js for hero section -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/particles.js/2.0.0/particles.min.js" integrity="sha512-Kef5sc7gfTacR7TZKelcrRs15ipf7+t+n7Zh6mKNJbmW+/RRdCW9nwfLn4YX0s2nO6Kv5Y2ChqgIakaC6PW09A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-
-    <script>
-      // The script tag above always loads (keeps the dependency graph static
-      // and analyzable by tools like Lighthouse); only the actual canvas
-      // animation is skipped for users who've asked the OS for reduced motion.
-      if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-        ['particles-js', 'skills', 'footer'].forEach(function (id) {
-          particlesJS.load(id, './dist/particles.json', function () {
-            console.log('particles.json loaded...');
-          });
-        });
-      }
-    </script>
 
     <script defer src="dist/js/app.js"></script>
 

--- a/scss/_contact.scss
+++ b/scss/_contact.scss
@@ -27,7 +27,7 @@
 
       i {
         font-size: 3.5rem;
-        color: $color-blue;
+        color: $color-blue-on-light;
         margin-bottom: 1rem;
         transition: 0.4s;
       }

--- a/scss/_experience.scss
+++ b/scss/_experience.scss
@@ -21,7 +21,7 @@
     border-radius: 3px;
     padding: 1.75rem 2rem;
     margin-bottom: 1.5rem;
-    border-left: 3px solid $color-blue;
+    border-left: 3px solid $color-blue-on-light;
 
     &:last-child {
       margin-bottom: 0;
@@ -42,9 +42,10 @@
   }
 
   .timeline-date {
-    color: $color-blue;
-    font-size: 0.85rem;
-    letter-spacing: 1px;
+    color: $color-blue-on-light;
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.8rem;
+    letter-spacing: 0.5px;
     text-transform: uppercase;
     white-space: nowrap;
   }
@@ -125,10 +126,11 @@
   }
 
   .home-blog-date {
-    color: $color-blue;
+    color: $color-blue-on-light;
+    font-family: "IBM Plex Mono", monospace;
     font-size: 0.8rem;
     text-transform: uppercase;
-    letter-spacing: 1px;
+    letter-spacing: 0.5px;
   }
 
   .home-blog-cta {

--- a/scss/_footer.scss
+++ b/scss/_footer.scss
@@ -1,17 +1,7 @@
 .footer {
   background: $dark-grey;
   padding: 1.5rem 0;
-  color: white;
-
-  // Particles.js canvas
-  canvas {
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 100%;
-    height: 100%;
-  }
+  color: $text-color;
 
   .footer-flex {
     display: flex;

--- a/scss/_globals.scss
+++ b/scss/_globals.scss
@@ -12,7 +12,7 @@ html {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
-  font-family: "Nunito", sans-serif;
+  font-family: "IBM Plex Sans", sans-serif;
 }
 
 body {
@@ -30,7 +30,13 @@ a {
 }
 
 .main-font {
-  font-family: "Nunito", sans-serif;
+  font-family: "IBM Plex Sans", sans-serif;
+}
+
+// Technical/utility face -- dates, tags, stack labels, nav: anywhere the
+// content is data rather than prose gets the monospace face, on purpose.
+.mono-font {
+  font-family: "IBM Plex Mono", monospace;
 }
 
 // Utility classes
@@ -59,8 +65,10 @@ a {
 }
 
 // Text
+// Default assumes the more common case (used on a white section); dark
+// sections (header/hero, Skills) override this locally -- see those files.
 .text-blue {
-  color: $color-blue;
+  color: $color-blue-on-light;
 }
 
 .text-white {
@@ -101,7 +109,9 @@ a {
 .btn {
   @extend %btn-shared;
   &-blue {
-    color: white;
+    // $color-blue is a LIGHT amber used as a background here -- needs
+    // dark text on top, not white (white-on-amber is ~1.76:1, fails badly).
+    color: $on-accent;
     @extend %btn-shared;
     background-color: $color-blue;
     border: 2px solid $color-blue;
@@ -109,15 +119,17 @@ a {
 
   &-dark {
     @extend %btn-shared;
-    color: white;
+    color: $text-color;
     background-color: $dark-grey;
   }
 
   &-blue-outline {
+    // Default assumes a white-section usage (Projects "Code" links etc.);
+    // header overrides this back to the light on-dark variant.
     @extend %btn-shared;
-    color: $color-blue;
+    color: $color-blue-on-light;
     background-color: transparent;
-    border: 2px solid $color-blue;
+    border: 2px solid $color-blue-on-light;
   }
 
   &-blue:hover {
@@ -127,8 +139,11 @@ a {
   }
 
   &-blue-outline:hover {
-    color: white;
+    // Filling solid with the light amber on hover -- dark text regardless
+    // of which text variant this button started with.
+    color: $on-accent;
     background-color: $color-blue;
+    border: 2px solid $color-blue;
   }
 
   &-small {
@@ -159,14 +174,19 @@ a {
 }
 
 // Credit: https://codepen.io/aaroniker/pen/BajabVN
+// Colors updated to the new palette. --text was #fff, which is nearly
+// invisible here: this button has no opaque background of its own
+// (background: none, below) and sits on the white .contact section, so
+// white text had ~1:1 contrast against it at rest -- fixed to dark text
+// to match every other place the light amber accent is used as a surface.
 .btn-email {
-  --primary: #3b82f6;
-  --primary-dark: #0455d8;
-  --primary-darkest: #013281;
+  --primary: #{$color-blue};
+  --primary-dark: #d98d2b;
+  --primary-darkest: #93591a;
   --shadow: #{rgba(#000, 0.3)};
-  --text: #fff;
+  --text: #{$on-accent};
   --text-opacity: 1;
-  --success: #3b82f6;
+  --success: #{$color-blue-on-light};
   --success-x: -12;
   --success-stroke: 14;
   --success-opacity: 0;
@@ -178,7 +198,7 @@ a {
   --plane-x: 0;
   --plane-y: 0;
   --plane-opacity: 1;
-  --trails: #{rgba(#3b82f6, 0.15)};
+  --trails: #{rgba($color-blue, 0.15)};
   --trails-stroke: 57;
   --left-wing-background: var(--primary);
   --left-wing-first-x: 0;
@@ -354,9 +374,11 @@ a {
   }
 }
 
+// Used only in the hero paragraph, on the dark background -- teal as a
+// secondary accent, distinct from the amber used for primary CTAs/buttons.
 .blue-link-underline {
-  color: #0b63f3;
-  border-bottom: 1px solid #0b63f3;
+  color: $color-teal;
+  border-bottom: 1px solid $color-teal;
 }
 
 .flex {

--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -1,26 +1,15 @@
 header {
   background: $dark-grey;
-  background-size: cover;
-  min-height: 80vh;
   position: relative;
-
-  #particles-js {
-    height: 80vh;
-    position: relative;
-
-    // Particles.js canvas
-    canvas {
-      position: absolute;
-      top: 0;
-      left: 0;
-      bottom: 0;
-      width: 100%;
-      height: 100%;
-    }
-  }
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 4rem;
 
   nav {
     width: 100%;
+    padding-top: 1.5rem;
+
     .nav-container {
       position: relative;
       display: flex;
@@ -45,8 +34,10 @@ header {
         }
         a {
           text-decoration: none;
-          letter-spacing: 2px;
+          letter-spacing: 1px;
           color: $text-color;
+          font-family: "IBM Plex Mono", monospace;
+          font-size: 0.9rem;
         }
         .link::after {
           content: "";
@@ -56,7 +47,7 @@ header {
           height: 2px;
           top: 3px;
           margin: auto;
-          background: #3b82f6;
+          background: $color-blue;
           transition: width 0.3s ease;
         }
         .link:hover::after {
@@ -79,6 +70,10 @@ header {
             list-style-type: none;
             li {
               margin: 0rem 1rem;
+              a {
+                font-family: "IBM Plex Mono", monospace;
+                font-size: 0.9rem;
+              }
             }
             .link::after {
               content: "";
@@ -100,40 +95,95 @@ header {
     }
   }
 
-  // Hero Section
+  // Hero section -- flexbox, not absolute-position-plus-transform centering.
+  // The old approach centered the hero on a fixed-percentage point within a
+  // vh-based header height, with nothing constraining it to actually fit --
+  // longer copy or a taller viewport-height breakpoint could (and did) push
+  // hero content up over the nav. min-height here is a floor, not a box:
+  // content is always fully contained and can never overlap a sibling.
   .hero {
     z-index: 5;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 3rem 1.5rem 2rem;
+
+    // The pipeline signature: a small DAG -- one source, three parallel
+    // stages, one sink -- standing in for the decorative particle
+    // background this section used to have. It's not incidental decoration;
+    // it's literally the shape of the thing Brett's job is building.
+    .hero-pipeline {
+      width: min(100%, 460px);
+      margin-bottom: 1.5rem;
+
+      svg {
+        width: 100%;
+        height: auto;
+        display: block;
+        overflow: visible;
+      }
+
+      .edge path {
+        fill: none;
+        stroke: $text-light;
+        stroke-width: 1.5;
+        stroke-dasharray: 6 6;
+        animation: pipeline-flow 1.4s linear infinite;
+      }
+
+      .node circle {
+        stroke: $dark-grey;
+        stroke-width: 2;
+      }
+
+      .node-endpoint circle {
+        fill: $color-blue;
+      }
+
+      .node-stage circle {
+        fill: $color-teal;
+        animation: pipeline-pulse 2.4s ease-in-out infinite;
+
+        &:nth-child(2) {
+          animation-delay: 0.25s;
+        }
+        &:nth-child(3) {
+          animation-delay: 0.5s;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .edge path,
+        .node-stage circle {
+          animation: none;
+        }
+      }
+    }
+
+    .hero-content {
+      max-width: 800px;
+    }
 
     h1,
     p {
       color: $text-color;
     }
 
-    h1,
-    h2 span {
-      letter-spacing: 2px;
-      white-space: nowrap;
-      text-align: center;
+    h1 {
+      letter-spacing: 1px;
       font-size: clamp(2rem, 5vw, 4rem);
-      font-weight: bold;
+      font-weight: 700;
     }
 
     p {
       color: $text-light;
       line-height: 1.6;
-      font-size: clamp(1.25rem, 2vw, 1.5rem);
-      text-align: center;
-      max-width: 800px;
-      margin: 0 auto;
+      font-size: clamp(1.1rem, 2vw, 1.35rem);
+      margin: 0.75rem auto 0;
       padding: 0.5rem;
-
-      .blue-link-underline {
-        color: #3783ff;
-      }
     }
 
     .hero-btns {
@@ -153,11 +203,23 @@ header {
         }
       }
     }
+
+    // On the dark hero, .text-blue/.btn-blue-outline need the light
+    // (on-dark) accent variant -- the site-wide default assumes a white
+    // section, since most usages are on one. See _variables.scss.
+    .text-blue {
+      color: $color-blue;
+    }
+
+    .btn-blue-outline {
+      color: $color-blue;
+      border-color: $color-blue;
+    }
   }
 
   .socials {
     position: absolute;
-    bottom: 40%;
+    bottom: 8%;
     left: -125px;
     z-index: 10;
 
@@ -172,8 +234,13 @@ header {
         display: flex;
         justify-content: end;
         font-size: 1.5rem;
-        width: 100%;
         height: 100%;
+
+        // The LinkedIn icon sits on the (light) accent background -- needs
+        // dark text/icon on top, same reasoning as the buttons.
+        &.bg-blue a {
+          color: $on-accent;
+        }
 
         a {
           text-align: right;
@@ -188,58 +255,6 @@ header {
 
         &:hover {
           transform: translateX(115px);
-        }
-      }
-    }
-  }
-
-  .scroll-btn-container {
-    position: absolute;
-    width: 100%;
-    background: red;
-    bottom: 150px;
-
-    div {
-      display: flex;
-      justify-content: center;
-      width: 100%;
-      a {
-        // height: 50px;
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-
-        span {
-          display: block;
-          height: 20px;
-          width: 20px;
-          border-bottom: 2px solid $color-blue;
-          border-right: 2px solid $color-blue;
-          transform: rotate(45deg);
-          margin: -20px 0;
-          animation: animate 2s infinite;
-        }
-
-        span:nth-child(2) {
-          animation-delay: -0.2s;
-        }
-
-        span:nth-child(3) {
-          animation-delay: -0.4s;
-        }
-
-        @keyframes animate {
-          0% {
-            opacity: 0;
-            transform: rotate(45deg) translate(-20px, -20px);
-          }
-          50% {
-            opacity: 1;
-          }
-          100% {
-            opacity: 0;
-            transform: rotate(45deg) translate(20px, 20px);
-          }
         }
       }
     }
@@ -264,6 +279,22 @@ header {
   }
 }
 
+@keyframes pipeline-flow {
+  to {
+    stroke-dashoffset: -24;
+  }
+}
+
+@keyframes pipeline-pulse {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
 // Media queries
 @media screen and (max-width: 999px) {
   header {
@@ -276,10 +307,6 @@ header {
       }
     }
 
-    .hero {
-      top: 55%;
-    }
-
     .socials {
       display: none;
     }
@@ -287,10 +314,6 @@ header {
 }
 
 @media screen and (max-width: 768px) {
-  .hero {
-    width: 90%;
-  }
-
   header nav .nav-container #logo img {
     width: 200px;
   }
@@ -315,24 +338,6 @@ header {
           }
         }
       }
-    }
-    .hero {
-      span {
-        max-width: 100%;
-      }
-      p {
-        width: 100%;
-      }
-    }
-  }
-}
-
-@media screen and (min-height: 900px) {
-  header {
-    min-height: 70vh;
-
-    #particles-js {
-      height: 70vh;
     }
   }
 }

--- a/scss/_skills.scss
+++ b/scss/_skills.scss
@@ -3,21 +3,17 @@
   position: relative;
   overflow: hidden;
 
-  // Particles.js canvas
-  canvas {
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 100%;
-    height: 100%;
-  }
-
   h2,
   h2 span {
     text-align: center;
     margin-bottom: 3rem;
     font-weight: bold;
+  }
+
+  // Dark section -- same reasoning as header: .text-blue needs the light
+  // on-dark accent variant here, not the site-wide white-section default.
+  .text-blue {
+    color: $color-blue;
   }
 
   .container {
@@ -48,8 +44,9 @@
       flex-direction: column;
       justify-content: center;
       align-items: center;
-      color: white;
-      font-size: 1rem;
+      color: $text-color;
+      font-family: "IBM Plex Mono", monospace;
+      font-size: 0.9rem;
       margin: 1rem;
 
       @media (max-width: 420px) {

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,10 +1,41 @@
 $website-width: 1200px;
-// #2563eb, not the original #3b82f6 — that shade fails WCAG AA contrast
-// (3.68:1) both as white-on-blue button text and as blue-on-white link text.
-// This shade clears 4.5:1 in both directions while staying in the same
-// Tailwind blue family (blue-500 -> blue-600).
-$color-blue: #2563eb;
-$dark-grey: #181a1b;
-$text-color: white;
-$text-light: #dcdcdc;
+
+// Visual identity, v2: a data-pipeline/DAG-inspired palette instead of the
+// generic "dark background, one blue accent" look most portfolio sites
+// default to. Variable names kept as-is (legacy from the original palette)
+// to avoid a full find/replace of every .text-blue/.btn-blue/.bg-blue class
+// across the templates -- what changed is what these tokens resolve to,
+// not their names.
+//
+// $color-blue is now a warm amber (terminal/pipeline-monitor coded, not
+// "SaaS blue"). It's LIGHT, so as a BACKGROUND (buttons, bg-blue) it always
+// needs dark text on top -- see $on-accent below.
+//
+// As TEXT color it's a different story: one color cannot pass 4.5:1
+// contrast against both white and near-black at once (the math doesn't
+// allow it -- confirmed by scanning the whole hue for an overlap; there
+// isn't one). This site has both light sections (Projects/Education/
+// Contact) and dark ones (header/hero, Skills), and .text-blue/
+// .btn-blue-outline get used in both. So there are two text variants:
+//   $color-blue          - light amber, for text on DARK sections
+//   $color-blue-on-light - darker amber-gold, for text on WHITE sections
+// Default utility classes below assume the (more common) white-section
+// case; header/.skills override back to $color-blue locally since those
+// sections are dark. Get this wrong and it's not a style nitpick -- it's
+// the same contrast bug from Phase C, just reintroduced by the redesign.
+//
+// Verified contrast (WCAG):
+//   text 16.18:1 vs bg, text-light 6.29:1 vs bg
+//   color-blue: 10.9:1 vs bg, 1.76:1 vs white (dark-section text only)
+//   color-blue-on-light: 5.06:1 vs white (light-section text only)
+//   color-teal: 10.75:1 vs bg (hero-only, dark background)
+//   on-accent (dark text on the light amber background): 10.9:1
+$color-blue: #ffb454;
+$color-blue-on-light: #996313;
+$color-teal: #4fd6c4;
+$dark-grey: #0b0f14;
+$surface: #131a22;
+$text-color: #e7ecf2;
+$text-light: #8695a7;
+$on-accent: $dark-grey;
 


### PR DESCRIPTION
Triggered by a real bug report (nav overlapping hero text on wide/ short viewports) and the plan's own finding: both the hiring-manager research and the frontend-design skill's philosophy flagged the old particles.js hero as decorative-default rather than tied to Brett's actual field. This redesign fixes the root structural bug and replaces the generic look with something grounded in the subject.

Root-cause fix (the reported bug):
- .hero used position:absolute + transform:translate(-50%,-50%) to center within a vh-based header height, with nothing constraining it to fit -- a longer hero paragraph (from the LinkedIn update) or a taller viewport could push content up over the nav, which is exactly what got reported. Replaced with header as a flex column (min-height:100vh) and .hero as flex:1, centered via flexbox -- content is always fully contained, structurally cannot overlap a sibling regardless of copy length or viewport dimensions. Verified across 5 viewports including the wide/short combination that triggered the original bug.

Visual identity:
- New palette: near-black-blue background instead of neutral dark grey, warm amber + teal accents instead of generic "blue on dark" (one of the explicitly-named default AI-portfolio looks). One color cannot pass 4.5:1 contrast against both white and near-black at once (confirmed by scanning the full hue -- no overlap exists), so there are two accent variants: light amber for dark sections (header, Skills), darker amber-gold for white sections (Projects, Education, Contact) -- get this wrong and it's the same contrast bug from Phase C, reintroduced.
- New signature element: particles.js replaced entirely with a small CSS-animated SVG DAG (one source, three parallel stages, one sink) -- not decorative, it's literally the shape of a data pipeline, which is the actual subject matter here. Removes a JS dependency and its performance cost as a side effect.
- Typography: IBM Plex Sans + IBM Plex Mono replace Nunito (plus Alfa Slab One and Alegreya, which turned out to be loaded but never actually applied anywhere -- dead font requests). Mono face used for dates/tags/nav -- technical content gets a technical typeface, on purpose, not decoratively.

Bugs found and fixed along the way (all via actual verification, not assumption):
- The .btn-email "Send" button's text was #fff with no opaque background of its own, sitting on the white Contact section -- effectively invisible at rest. Confirmed via screenshot, fixed to dark text.
- Two pre-existing malformed anchor tags (<a>text<a> instead of <a>text</a>, in the Email and GitHub contact cards) were causing the browser to nest the following <h3> inside the unclosed anchor, inheriting the link color -- rendered as light text on the white card background, nearly invisible. Confirmed by checking computed color before/after; fixed the actual malformed HTML rather than papering over it with a CSS override.
- .timeline-date, .home-blog-date, and contact-card icons were using the (light, on-dark) accent directly on white sections -- same contrast failure class as the Phase C bug, just not yet shipped.

Compiled dist/css/styles.css with an actual Sass compiler (npx sass, now available in this environment) instead of hand-translating -- far more reliable for a change this size than the manual approach used for smaller fixes earlier this session.

Caught mid-task: had been committing directly to main instead of a branch for this work -- branched before this commit so nothing shipped without review.