### PR TITLE
Fix stretched logo aspect ratio

### DIFF
--- a/dist/css/styles.css
+++ b/dist/css/styles.css
@@ -376,6 +376,7 @@ header nav .nav-container #logo {
 }
 header nav .nav-container #logo img {
   width: 250px;
+  height: auto;
 }
 header nav .nav-container .nav-links {
   z-index: 1000;
@@ -615,6 +616,7 @@ header .seperator-skew svg .fill-white {
 @media screen and (max-width: 768px) {
   header nav .nav-container #logo img {
     width: 200px;
+    height: auto;
   }
 }
 @media screen and (max-width: 500px) {
@@ -1113,6 +1115,7 @@ header .seperator-skew svg .fill-white {
 }
 .footer .footer-flex #logo-footer {
   width: 200px;
+  height: auto;
 }
 .footer .footer-flex .top-scroll-button {
   cursor: pointer;

--- a/scss/_footer.scss
+++ b/scss/_footer.scss
@@ -8,7 +8,10 @@
     justify-content: space-between;
 
     #logo-footer {
+      // Same fix as the nav logo: width-only CSS let the height="560"
+      // HTML attribute win unopposed, squashing the aspect ratio.
       width: 200px;
+      height: auto;
     }
 
     .top-scroll-button {

--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -19,7 +19,13 @@ header {
         margin: auto 0;
         z-index: 10;
         img {
+          // The HTML width/height attributes (added for Lighthouse's
+          // unsized-images check) act as low-priority implicit styles.
+          // This rule only overrode width, so the height="560" attribute
+          // was winning unopposed -- squashing the image into a 250x560
+          // box instead of preserving its real ~2.79:1 aspect ratio.
           width: 250px;
+          height: auto;
         }
       }
 
@@ -316,6 +322,7 @@ header {
 @media screen and (max-width: 768px) {
   header nav .nav-container #logo img {
     width: 200px;
+    height: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- The nav and footer logo images were rendering squashed (250×560 / 200×560 instead of their real ~2.79:1 ratio)
- Root cause: the HTML `width`/`height` attributes (added for Lighthouse's unsized-images check) were winning as implicit low-priority CSS, since `#logo img` / `#logo-footer` only overrode `width`
- Fix: added `height: auto` alongside the existing `width` rules (desktop nav, mobile nav, footer)

## Test plan
- [x] Recompiled SCSS → `dist/css/styles.css`
- [x] Verified locally with Playwright against the actual file: rendered ratio now `2.791` for both logos, matching the natural image ratio `2.791` (was `250 / 89.6px` correctly proportioned vs. previously forced to 560px tall)
- [x] Screenshot-confirmed visually — logo displays correctly, no squash