### PR TITLE
Fix icon sizing broken by the Font Awesome -> SVG migration

### DIFF
--- a/dist/css/styles.css
+++ b/dist/css/styles.css
@@ -578,8 +578,9 @@ header .socials ul li a {
   width: 100%;
   padding: 15px 20px;
 }
-header .socials ul li a i {
-  font-size: 1.75rem;
+header .socials ul li a .icon {
+  width: 1.75rem;
+  height: 1.75rem;
   margin-left: 1.5rem;
 }
 header .socials ul li:hover {
@@ -706,8 +707,9 @@ header .seperator-skew svg .fill-white {
   border: 1px solid lightgray;
   min-height: 300px;
 }
-.project-left.icon-tile i {
-  font-size: 5rem;
+.project-left.icon-tile .icon {
+  width: 5rem;
+  height: 5rem;
   color: #ffb454;
 }
 
@@ -774,8 +776,9 @@ header .seperator-skew svg .fill-white {
   .project-left.icon-tile {
     min-height: 200px;
   }
-  .project-left.icon-tile i {
-    font-size: 3.5rem;
+  .project-left.icon-tile .icon {
+    width: 3.5rem;
+    height: 3.5rem;
   }
 }
 .projects {
@@ -1043,13 +1046,14 @@ header .seperator-skew svg .fill-white {
   box-shadow: 0 0.15rem 0.6rem rgba(43, 52, 56, 0.15);
   border-radius: 3px;
 }
-.contact .card-container .card i {
-  font-size: 3.5rem;
+.contact .card-container .card .icon {
+  width: 3.5rem;
+  height: 3.5rem;
   color: #996313;
   margin-bottom: 1rem;
   transition: 0.4s;
 }
-.contact .card-container .card i:hover {
+.contact .card-container .card .icon:hover {
   transform: translateY(-20%);
 }
 .contact .card-container .card > * {
@@ -1155,10 +1159,10 @@ header .seperator-skew svg .fill-white {
 .footer .footer-flex .footer-icon-links a:hover {
   color: #ffb454;
 }
-.footer .footer-flex .footer-icon-links a i {
+.footer .footer-flex .footer-icon-links a .icon {
   transition: 0.3s;
 }
-.footer .footer-flex .footer-icon-links a i:hover {
+.footer .footer-flex .footer-icon-links a .icon:hover {
   transform: translateY(-20%);
 }
 

--- a/scss/_contact.scss
+++ b/scss/_contact.scss
@@ -25,14 +25,15 @@
       box-shadow: 0 0.15rem 0.6rem rgba(43, 52, 56, 0.15);
       border-radius: 3px;
 
-      i {
-        font-size: 3.5rem;
+      .icon {
+        width: 3.5rem;
+        height: 3.5rem;
         color: $color-blue-on-light;
         margin-bottom: 1rem;
         transition: 0.4s;
       }
 
-      i:hover {
+      .icon:hover {
         transform: translateY(-20%);
       }
 

--- a/scss/_experience.scss
+++ b/scss/_experience.scss
@@ -76,8 +76,9 @@
   border: 1px solid lightgray;
   min-height: 300px;
 
-  i {
-    font-size: 5rem;
+  .icon {
+    width: 5rem;
+    height: 5rem;
     color: $color-blue;
   }
 }
@@ -156,8 +157,9 @@
   .project-left.icon-tile {
     min-height: 200px;
 
-    i {
-      font-size: 3.5rem;
+    .icon {
+      width: 3.5rem;
+      height: 3.5rem;
     }
   }
 }

--- a/scss/_footer.scss
+++ b/scss/_footer.scss
@@ -39,7 +39,7 @@
         color: $color-blue;
       }
 
-      i {
+      .icon {
         transition: 0.3s;
         &:hover {
           transform: translateY(-20%);

--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -253,8 +253,9 @@ header {
           height: 100%;
           width: 100%;
           padding: 15px 20px;
-          i {
-            font-size: 1.75rem;
+          .icon {
+            width: 1.75rem;
+            height: 1.75rem;
             margin-left: 1.5rem;
           }
         }


### PR DESCRIPTION
## Summary
Found during a visual polish pass — the earlier inline-SVG-icons PR replaced every `<i class="fa...">` with `<svg class="icon">`, but 5 CSS rules across 4 files still targeted a bare `i` selector and silently stopped matching anything:

- **Project placeholder cards** (NHL Arena Web Interface, TechNest — no screenshot available) lost their intended 5rem centered icon, shrinking to a barely-visible dark speck
- **Contact cards** (Email/GitHub/LinkedIn) lost their 3.5rem size and orange color the same way
- **Hero sidebar + footer social icons** lost their hover lift micro-interaction, and the sidebar icons would have rendered at the wrong size without this fix

Fixed by changing each `i { ... }` to `.icon { ... }` (width/height instead of font-size, since these are sized SVG elements now, not font glyphs).

## Test plan
- [x] Verified all three affected areas render at their originally-intended size again — direct measurement + screenshot comparison, desktop and mobile
- [x] Confirmed the one legitimate `<i>` (italic text, unrelated to icons) elsewhere on the page isn't in scope of any of these selectors