### PR TITLE
Add a <main> landmark and a no-JS safety net for AOS content

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="no-js">
   <head>
+    <!-- See index.html for why this matters -- AOS's CSS hides [data-aos]
+         content behind html:not(.no-js), so without this, no-JS visitors
+         would never see most of the page. -->
+    <script>document.documentElement.classList.remove('no-js');</script>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/index.html
+++ b/index.html
@@ -1,8 +1,14 @@
 ---
 ---
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="no-js">
   <head>
+    <!-- AOS's CSS gates its opacity:0 fade-in prep behind html:not(.no-js) --
+         this removes that class the instant JS is confirmed running. Without
+         it, any user with JS disabled (or a failed/blocked AOS script load)
+         would see every [data-aos] section stay invisible forever, since
+         nothing would ever add the .aos-animate class that reveals them. -->
+    <script>document.documentElement.classList.remove('no-js');</script>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -231,6 +237,7 @@
 
     </header>
 
+    <main>
     <!-- EXPERIENCE -->
     <section id="experience" class="experience">
       <div class="container">
@@ -515,6 +522,7 @@
         </form>
       </div>
     </section>
+    </main>
 
     <footer id="footer" class="footer">
       <div class="container">


### PR DESCRIPTION
## Summary
Found via automated testing (axe-core + a no-JS run) prompted by "test what you can":

1. **Missing `<main>` landmark** — axe-core flagged `index.html` (the blog layout already had one) for ~50 nodes of content not contained by any landmark region. Wrapped Experience/Projects/Skills/Education/Blog-teaser/Contact in `<main>`.

2. **The big one** — tested the live site with JavaScript disabled and found the entire page below the hero was permanently invisible. AOS's own CSS anticipates this exact case (`html:not(.no-js) [data-aos]{opacity:0}`), but we never set/removed the `no-js` class it depends on, so the opacity:0 rule applied unconditionally — meaning *any* visitor with JS disabled, or where the AOS script from unpkg.com fails to load for any reason (blocked, CDN hiccup, flaky connection), would see most of the page as blank. Fixed with the standard pattern this library expects.

## Test plan
- [x] axe-core: 2 landmark violations → 0 (confirmed against a rendered copy; also verified the earlier `document-title`/`color-contrast` axe findings from raw local testing were artifacts of not running through Jekyll, not real issues)
- [x] No-JS: content now renders fully visible immediately (previously: blank)
- [x] JS enabled: verified unchanged — elements still start hidden and reveal correctly on scroll (0 stuck elements after a full scroll-through)
- [x] Applied to both `index.html` and `_layouts/default.html` (blog pages run AOS independently)