### PR TITLE
Fix GitHub capitalization in the hero button

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
                 target="_blank"><svg class="icon" aria-hidden="true" focusable="false"><use href="#fa-file-download"></use></svg> Resume</a
               >
               <a href="https://github.com/brettadams0" class="btn-blue-outline mx-1" id="projects-btn"
-                target="_blank"><svg class="icon" aria-hidden="true" focusable="false"><use href="#fa-github"></use></svg> Github</a
+                target="_blank"><svg class="icon" aria-hidden="true" focusable="false"><use href="#fa-github"></use></svg> GitHub</a
               >
             </div>
           </div>


### PR DESCRIPTION
## Summary
Proofread the site's actual rendered text — every instance says "GitHub" except the hero button, which said "Github". Fixed for consistency.