### PR TITLE
Polish The Bargain Hunt's brief screen ahead of handover

### DIFF
--- a/bargain-hunt/app.js
+++ b/bargain-hunt/app.js
@@ -102,7 +102,7 @@
 
     // Never draw a bar from invented numbers (spec §11 degradation).
     if (!isNum(price) || !isNum(low52) || !isNum(high52) || high52 <= low52) {
-      return el("p", { class: "range-caption", text: "52-week range not confirmed." });
+      return el("div", { class: "range-unknown" }, "52-week range not confirmed");
     }
 
     const span = high52 - low52;
@@ -169,7 +169,7 @@
 
     return el(
       "article",
-      { class: "card" },
+      { class: `card v-${VERDICT_CLASS[verdict] || "neutral"}` },
       el(
         "div",
         { class: "card-head" },
@@ -241,7 +241,7 @@
       c.right
         ? el(
             "div",
-            { class: "section" },
+            { class: "section pair right" },
             el("div", { class: "label" }, "Must go right"),
             el("p", { text: c.right })
           )
@@ -250,7 +250,7 @@
       c.wrong
         ? el(
             "div",
-            { class: "section" },
+            { class: "section pair wrong" },
             el("div", { class: "label" }, "Could go wrong"),
             el("p", { text: c.wrong })
           )
@@ -317,9 +317,13 @@
     return el(
       "details",
       { class: "disclaimer" },
-      el("summary", { text: "Important" }),
+      el("summary", { text: "Not investment advice — tap to read" }),
       el("p", { text: BH.DISCLAIMER })
     );
+  }
+
+  function footnote() {
+    return el("p", { class: "footnote", text: "A new brief arrives each morning" });
   }
 
   function briefScreen() {
@@ -386,10 +390,15 @@
       const v = String(c.verdict || "").toLowerCase();
       counts[v] = (counts[v] || 0) + 1;
     }
-    const parts = [];
-    if (counts["real bargain"]) parts.push(`${counts["real bargain"]} real bargain`);
-    if (counts["wait and see"]) parts.push(`${counts["wait and see"]} to watch`);
-    if (counts["value trap"]) parts.push(`${counts["value trap"]} value trap`);
+    const tallies = [
+      ["real bargain", "bargain", "real bargain"],
+      ["wait and see", "wait", "to watch"],
+      ["value trap", "trap", "value trap"],
+    ]
+      .filter(([key]) => counts[key])
+      .map(([key, cls, label]) =>
+        el("span", { class: `tally ${cls}`, text: `${counts[key]} ${label}` })
+      );
 
     nodes.push(
       el(
@@ -399,14 +408,14 @@
           class: "count",
           text: `${shown.length} candidate${shown.length === 1 ? "" : "s"}`,
         }),
-        parts.length ? el("div", { class: "breakdown", text: parts.join(" · ") }) : null,
+        tallies.length ? el("div", { class: "breakdown" }, tallies) : null,
         brief.note ? el("p", { class: "note", text: brief.note }) : null,
         // Be explicit that a wider screen ran behind this, so a thin list
         // reads as "my filters are tight", not "nothing happened today".
         all.length > shown.length
           ? el("p", {
-              class: "range-caption",
-              text: `Screened ${all.length}, showing the ${shown.length} that match your settings.`,
+              class: "screened",
+              text: `Screened ${all.length} · showing the ${shown.length} that match your settings`,
             })
           : null
       )
@@ -414,6 +423,7 @@
 
     nodes.push(...shown.map(tearsheet));
     nodes.push(disclaimerBlock());
+    nodes.push(footnote());
     return nodes;
   }
 

--- a/bargain-hunt/styles.css
+++ b/bargain-hunt/styles.css
@@ -203,41 +203,87 @@ main {
 
 /* --------------------------------------------------------------- summary */
 
+/* The masthead. He reads this first, so it gets the page's only large type
+   and a rule to separate it from the tearsheets. */
 .summary {
   display: grid;
-  gap: 4px;
+  gap: 5px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--line);
 }
 
 .summary .count {
   font-family: var(--font-display);
   font-weight: 700;
-  font-size: 1.5rem;
-  letter-spacing: -0.02em;
+  font-size: 1.9rem;
+  letter-spacing: -0.03em;
+  line-height: 1.1;
 }
 
 .summary .breakdown {
-  font-family: var(--font-mono);
-  font-size: 0.82rem;
-  font-weight: 500;
-  color: var(--ink-muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 8px;
+  margin-top: 3px;
 }
 
+.summary .tally {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  background: color-mix(in srgb, currentColor 12%, transparent);
+  white-space: nowrap;
+}
+
+.summary .tally.bargain { color: var(--bargain); }
+.summary .tally.wait    { color: var(--wait); }
+.summary .tally.trap    { color: var(--trap); }
+
 .summary .note {
-  margin-top: 6px;
+  margin-top: 9px;
+  color: var(--ink);
+  font-size: 1.02rem;
+}
+
+.summary .screened {
+  margin: 2px 0 0;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  letter-spacing: 0.02em;
   color: var(--ink-muted);
 }
 
 /* ------------------------------------------------------------- tearsheet */
 
 .card {
+  position: relative;
   background: var(--surface);
   border: 1px solid var(--line);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
-  padding: 16px;
+  padding: 18px 16px 16px;
   display: grid;
-  gap: 14px;
+  gap: 15px;
+  overflow: hidden;
 }
+
+/* A colour-coded spine down the card. The verdict is legible before any
+   text is read, which is the point of leading with it. */
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: var(--ink-muted);
+}
+
+.card.v-bargain::before { background: var(--bargain); }
+.card.v-wait::before    { background: var(--wait); }
+.card.v-trap::before    { background: var(--trap); }
 
 .card-head {
   display: flex;
@@ -285,15 +331,16 @@ main {
 .prices {
   display: flex;
   align-items: baseline;
-  gap: 12px;
+  gap: 10px;
   flex-wrap: wrap;
   font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
 }
 
 .prices .now {
-  font-size: 1.45rem;
+  font-size: 1.6rem;
   font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
 .prices .prev {
@@ -340,6 +387,33 @@ main {
   color: var(--ink-muted);
 }
 
+/* When the 52-week range could not be confirmed we still draw the slot, so
+   the card keeps its rhythm and the gap reads as "not known" rather than as
+   something that failed to load. */
+.range-unknown {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px dashed var(--line);
+  border-radius: 10px;
+  color: var(--ink-muted);
+  font-size: 0.9rem;
+}
+
+.range-unknown::before {
+  content: "";
+  flex: none;
+  width: 34px;
+  height: 6px;
+  border-radius: 3px;
+  background: repeating-linear-gradient(
+    90deg,
+    var(--line) 0 5px,
+    transparent 5px 9px
+  );
+}
+
 /* ---------------------------------------------------------- text section */
 
 /* Structural, not decorative — they mark the fixed parts of every tearsheet
@@ -357,9 +431,28 @@ main {
   flex-wrap: wrap;
 }
 
-.section p {
-  margin: 4px 0 0;
+/* A hairline running off the end of each label, so the fixed sections of a
+   tearsheet are findable at a glance without adding weight. */
+.label::after {
+  content: "";
+  flex: 1;
+  min-width: 12px;
+  height: 1px;
+  background: var(--line);
 }
+
+.section p {
+  margin: 5px 0 0;
+}
+
+/* "Must go right" / "could go wrong" read as a pair. */
+.section.pair p {
+  padding-left: 11px;
+  border-left: 2px solid var(--line);
+}
+
+.section.pair.right p { border-left-color: color-mix(in srgb, var(--bargain) 55%, var(--line)); }
+.section.pair.wrong p { border-left-color: color-mix(in srgb, var(--trap) 55%, var(--line)); }
 
 .cause-type {
   font-size: 0.68rem;
@@ -383,22 +476,25 @@ main {
   /* The floor is in rem, not px, so the grid drops to fewer columns as the
      system font size grows instead of shredding values into "Neg ati ve". */
   grid-template-columns: repeat(auto-fit, minmax(7.5rem, 1fr));
+  /* 1px gaps over a line-coloured background draw perfect hairlines with no
+     doubled edges at the grid's rim. */
+  gap: 1px;
+  background: var(--line);
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: 10px;
   overflow: hidden;
 }
 
 .metric {
-  padding: 9px 8px;
-  border-right: 1px solid var(--line);
-  border-bottom: 1px solid var(--line);
+  padding: 10px 11px;
+  background: var(--surface);
   min-width: 0;
 }
 
 .metric .m-label {
   font-family: var(--font-mono);
   font-size: 11px;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.06em;
   color: var(--ink-muted);
   text-transform: uppercase;
   overflow-wrap: anywhere;
@@ -717,22 +813,49 @@ main {
 .disclaimer summary {
   padding: 12px 16px;
   cursor: pointer;
-  font-family: var(--font-mono);
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  font-size: 0.93rem;
   color: var(--ink-muted);
   min-height: var(--tap);
   display: flex;
   align-items: center;
+  gap: 10px;
+  list-style: none;
+}
+
+.disclaimer summary::-webkit-details-marker { display: none; }
+
+.disclaimer summary::before {
+  content: "";
+  flex: none;
+  width: 9px;
+  height: 9px;
+  border-right: 2px solid var(--ink-muted);
+  border-bottom: 2px solid var(--ink-muted);
+  transform: rotate(-45deg);
+  transition: transform 0.15s ease;
+}
+
+.disclaimer[open] summary::before {
+  transform: rotate(45deg);
 }
 
 .disclaimer p {
   margin: 0;
-  padding: 0 16px 16px;
+  padding: 0 16px 16px 35px;
   color: var(--ink-muted);
   font-size: 0.94rem;
+}
+
+/* Closes the page off, and answers "is this all there is?" without him
+   having to ask. */
+.footnote {
+  text-align: center;
+  padding: 4px 8px 8px;
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
+  color: var(--ink-muted);
 }
 
 .snackbar {


### PR DESCRIPTION
Visual pass over the brief screen before handing the app over. No behaviour changes — filtering, caching, syncing and the data contract are untouched.

- Each tearsheet gets a **colour-coded spine** matching its verdict, so the triage is legible before any text is read. That is the whole point of leading with the verdict.
- The summary becomes a **masthead**: larger count, the verdict breakdown as tinted tallies rather than a run-on line, and a rule separating it from the cards.
- An unconfirmed 52-week range now draws a **dashed placeholder** instead of a bare sentence, so a missing figure reads as "not known" rather than as something that failed to load. This matters here — the first real brief has several unconfirmed figures, by design.
- "Must go right" / "could go wrong" share a tinted rule, so they read as the pair they are.
- Section labels trail a hairline, making the fixed parts of a tearsheet findable without adding weight.
- Metric grid uses 1px gaps over a line-coloured background, removing the doubled borders at the grid's rim.
- The disclaimer gets a chevron and a plainer summary line, and the page closes with a quiet note that a new brief arrives each morning.

Full suite still passes, including 200% font scaling with no clipping or horizontal overflow, the null-range degradation, and the guard asserting the app never calls the Anthropic API. Verified in both light and dark.

---
_Generated by [Claude Code](https://claude.ai/code/session_014CgzP2epEZapmRFBZ2TBHR)_