### PR TITLE
State the real schedule: Tuesday to Saturday

### DIFF
--- a/bargain-hunt/README.md
+++ b/bargain-hunt/README.md
@@ -14,7 +14,7 @@ Claude Code session**, which searches the web, writes the brief, and publishes
 it. The app is a **reader**: it fetches that file, caches it, and renders it.
 
 ```
-  Scheduled Claude Code session (every morning)
+  Scheduled Claude Code session (Tue-Sat, 06:30 ET)
         │  reads hunt/PROMPT.md + hunt/watchlist.json
         │  searches the web, judges each candidate
         ▼
@@ -83,7 +83,7 @@ market cap, max forward P/E, dividend payers only, excluded sectors, how many
 to show. There is a live preview line so the combination is never a guess.
 
 These apply **instantly**, because the morning run deliberately screens wider
-than he needs — 8 candidates at a 10% threshold — and the phone narrows that
+than he needs — 6 candidates at a 10% threshold — and the phone narrows that
 to his thresholds locally. Tightening a filter re-filters the list immediately
 instead of waiting for tomorrow.
 
@@ -92,9 +92,24 @@ Only a value that definitely fails a test removes a candidate. "Never invent a
 figure" cuts both ways — a P/E the model could not confirm must not quietly
 hide a company.
 
-**The watchlist lives in the repo**, at `hunt/watchlist.json`, because the
-morning run is what checks those tickers. The Watch tab links straight to
-GitHub's editor for it, which works fine on a phone.
+**The watchlist lives on the phone.** He adds and removes tickers in the Watch
+tab — no account, no sign-in, and it persists in IndexedDB like the settings do.
+Each morning his tickers are matched against the day's screen: any that fell get
+the full write-up, and any that did not are marked "no double-digit fall today"
+rather than left looking broken.
+
+An earlier version kept the watchlist in `hunt/watchlist.json` and linked to
+GitHub's editor. That was wrong — **he does not have a GitHub account**, so the
+one control that was supposed to be his was the one he could not touch.
+
+`hunt/watchlist.json` still exists and is still read by the morning run, but it
+is now the optional *deep* list: names researched by ticker every morning
+whatever the price did, for anyone maintaining the repo. Entries from it appear
+in the Watch tab without a remove button, because the phone does not own them.
+
+There is deliberately no write-back from phone to repo. That would need a
+credential in a public web app, and GitHub revokes tokens it finds in public
+source — so it would break, and it would deserve to.
 
 ## What is degraded compared to the spec
 
@@ -105,10 +120,10 @@ GitHub's editor for it, which works fine on a phone.
   means "a run was actually missed".
 - **No on-demand single-ticker check.** §10.2 had tapping a watchlist row run
   a live check. Without an API key there is no live call, so the Watch tab
-  shows that morning's check instead. Given §24 — his bottleneck is gathering,
-  not judging — pre-gathered each morning still solves the actual problem.
-- **Adding a watchlist ticker is not one tap in the app.** It is an edit to
-  `watchlist.json` on GitHub, linked from the Watch tab.
+  shows that morning's reading instead. Given §24 — his bottleneck is gathering,
+  not judging — pre-gathered each morning still solves the actual problem. The
+  cost is that a watched name which did not fall gets no tearsheet that day
+  unless it is on the deep list.
 - **Settings shape the output, not the prompt.** §9 wanted every setting to
   change the prompt. Here the broad screen is fixed and settings filter the
   result. The trade is deliberate: settings became instant instead of
@@ -140,7 +155,7 @@ bargain-hunt/
 ├── manifest.json       standalone display, 192/512/maskable icons
 └── hunt/
     ├── PROMPT.md       the whole job, in plain English — this is the product
-    └── watchlist.json  tickers checked daily; editable on github.com
+    └── watchlist.json  optional deep list, researched by name every morning
 ```
 
 `hunt/PROMPT.md` is deliberately prose, not code. It is the part worth editing

--- a/bargain-hunt/app.js
+++ b/bargain-hunt/app.js
@@ -323,7 +323,12 @@
   }
 
   function footnote() {
-    return el("p", { class: "footnote", text: "A new brief arrives each morning" });
+    // Tuesday to Saturday, each covering the previous trading session. Saying
+    // so stops the Sunday/Monday gap reading as a failure.
+    return el("p", {
+      class: "footnote",
+      text: "New brief each morning, Tuesday to Saturday",
+    });
   }
 
   function briefScreen() {
@@ -429,12 +434,40 @@
 
   /* ----------------------------------------------------------- watchlist */
 
+  async function addTicker(raw) {
+    const t = String(raw).trim().toUpperCase();
+    if (!t) return;
+    if (state.settings.watchlist.includes(t)) {
+      snackbar(`${t} is already on your list.`);
+      return;
+    }
+    state.settings.watchlist = state.settings.watchlist.concat(t);
+    await BH.putSettings(state.settings);
+    render();
+  }
+
+  async function removeTicker(t) {
+    const idx = state.settings.watchlist.indexOf(t);
+    if (idx === -1) return;
+    state.settings.watchlist = state.settings.watchlist.filter((x) => x !== t);
+    await BH.putSettings(state.settings);
+    render();
+    snackbar(`Removed ${t}.`, "Undo", async () => {
+      const next = state.settings.watchlist.slice();
+      next.splice(Math.min(idx, next.length), 0, t);
+      state.settings.watchlist = next;
+      await BH.putSettings(state.settings);
+      render();
+    });
+  }
+
   function watchScreen() {
     const nodes = [];
     if (state.error) nodes.push(errorBanner());
 
-    const watch =
-      state.cached && Array.isArray(state.cached.brief.watch) ? state.cached.brief.watch : [];
+    const entries = state.cached
+      ? BH.watchEntries(state.cached.brief, state.settings)
+      : (state.settings.watchlist || []).map((t) => ({ ticker: t, candidate: null, deep: false }));
 
     if (state.detail) {
       nodes.push(
@@ -453,59 +486,106 @@
       return nodes;
     }
 
+    const input = el("input", {
+      type: "text",
+      class: "ticker-input",
+      maxlength: "6",
+      placeholder: "Add a ticker",
+      "aria-label": "Ticker to add",
+      autocapitalize: "characters",
+      autocomplete: "off",
+      spellcheck: "false",
+      enterkeyhint: "done",
+    });
+    input.addEventListener("input", () => {
+      input.value = input.value.toUpperCase().replace(/[^A-Z.\-]/g, "").slice(0, 6);
+    });
+    const submit = async () => {
+      const v = input.value;
+      input.value = "";
+      await addTicker(v);
+    };
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") submit();
+    });
+
     nodes.push(
       el(
         "div",
         { class: "group" },
         el("h2", { text: "Watchlist" }),
-        watch.length
-          ? watch.map((c) => {
-              const vclass = VERDICT_CLASS[String(c.verdict || "").toLowerCase()];
-              return el(
-                "div",
-                { class: "watch-row" },
-                el(
-                  "button",
-                  {
-                    class: "w-main",
-                    type: "button",
-                    onclick: () => {
+        el(
+          "div",
+          { class: "add-row" },
+          input,
+          el("button", { class: "btn", type: "button", text: "Add", onclick: submit })
+        ),
+        entries.map((entry) => {
+          const c = entry.candidate;
+          const vclass = c ? VERDICT_CLASS[String(c.verdict || "").toLowerCase()] : null;
+          const openable = !!c;
+          return el(
+            "div",
+            { class: "watch-row" },
+            el(
+              "button",
+              {
+                class: "w-main",
+                type: "button",
+                disabled: !openable,
+                onclick: openable
+                  ? () => {
                       state.detail = c;
                       render();
                       window.scrollTo({ top: 0 });
-                    },
-                    "aria-label": `Open ${c.ticker}`,
-                  },
-                  el("span", { class: "w-ticker", text: c.ticker || "—" }),
-                  c.name ? el("span", { class: "w-name", text: c.name }) : null
-                ),
-                c.verdict
-                  ? el("span", { class: `pill ${vclass || "neutral"}`, text: c.verdict })
-                  : null
-              );
-            })
-          : null,
-        el(
-          "div",
-          { class: "preview" },
-          "These are checked every morning alongside the screen. ",
-          el(
-            "a",
-            { href: BH.WATCHLIST_EDIT_URL, target: "_blank", rel: "noopener noreferrer" },
-            "Edit the list"
-          ),
-          " — it opens the file on GitHub, which works fine on a phone."
-        )
+                    }
+                  : null,
+                "aria-label": openable ? `Open ${entry.ticker}` : `${entry.ticker}, nothing today`,
+              },
+              el("span", { class: "w-ticker", text: entry.ticker }),
+              el("span", {
+                class: "w-name",
+                // Be plain about why a row is empty rather than looking broken.
+                text: c
+                  ? c.name || ""
+                  : entry.deep
+                  ? "no reading this morning"
+                  : "no double-digit fall today",
+              })
+            ),
+            c && c.verdict
+              ? el("span", { class: `pill ${vclass || "neutral"}`, text: c.verdict })
+              : null,
+            entry.deep
+              ? null
+              : el("button", {
+                  class: "remove",
+                  type: "button",
+                  text: "✕",
+                  "aria-label": `Remove ${entry.ticker}`,
+                  onclick: () => removeTicker(entry.ticker),
+                })
+          );
+        }),
+        el("div", {
+          class: "preview",
+          text:
+            "Your tickers are kept on this phone — nothing to sign into. Each " +
+            "morning they are matched against the day's screen, and any that " +
+            "fell get the full write-up here.",
+        })
       )
     );
 
-    if (!watch.length) {
+    if (!entries.length) {
       nodes.push(
         el(
           "div",
           { class: "state" },
-          el("h2", { text: "Nothing on the watchlist" }),
-          el("p", { text: "Add a ticker to have it checked every morning." })
+          el("h2", { text: "Nothing on the watchlist yet" }),
+          el("p", {
+            text: "Add a ticker above and it'll be checked against each morning's screen.",
+          })
         )
       );
     }
@@ -690,9 +770,11 @@
         el("div", {
           class: "preview",
           text:
-            "A scheduled job runs the hunt every morning and publishes the " +
-            "brief. This app just reads it — there is no API key on your " +
-            "phone and it costs nothing to run.",
+            "A scheduled job runs the hunt each morning from Tuesday to " +
+            "Saturday and publishes the brief — each one covers the previous " +
+            "trading day. On Sunday and Monday it keeps Saturday's, because " +
+            "Friday's close is still the newest there is. This app only " +
+            "reads it: no API key on your phone, nothing to run.",
         }),
         el(
           "div",

--- a/bargain-hunt/core.js
+++ b/bargain-hunt/core.js
@@ -27,12 +27,6 @@
     "https://raw.githubusercontent.com/brettadams0/brettadams0.github.io/" +
     "bargain-hunt-data/brief.json";
 
-  // Where to edit the tickers checked each morning. GitHub's file editor
-  // works fine on a phone.
-  const WATCHLIST_EDIT_URL =
-    "https://github.com/brettadams0/brettadams0.github.io/edit/main/" +
-    "bargain-hunt/hunt/watchlist.json";
-
   const FETCH_TIMEOUT_MS = 20000;
 
   // The morning run is Tuesday to Saturday, so each brief covers the previous
@@ -69,6 +63,10 @@
     dividendPayersOnly: false,
     excludedSectors: [],
     candidateCount: 3,
+    // His own tickers, kept on the phone. No account, no sign-in, and he can
+    // change them himself — the previous design needed a GitHub login he
+    // does not have.
+    watchlist: [],
     notifyOnNewBrief: true,
     notifyOnWatchlistDrop: true,
   };
@@ -256,6 +254,40 @@
     return out;
   }
 
+  // What the Watch tab shows: one row per ticker he is watching, carrying
+  // today's tearsheet when the morning run covered it.
+  //
+  // Two sources feed it. `brief.watch` is the deep list the morning run
+  // researches by name every day, whatever the price did. The day's screen
+  // covers everything else — so a ticker he added on the phone gets a full
+  // tearsheet on any morning it actually fell, and is honestly marked quiet
+  // otherwise. That keeps the tab useful without needing the phone to write
+  // anywhere, which is what would have required an account.
+  function watchEntries(brief, s) {
+    const byTicker = new Map();
+    const add = (c, deep) => {
+      const t = String(c && c.ticker ? c.ticker : "").toUpperCase();
+      if (!t || byTicker.has(t)) return;
+      byTicker.set(t, { ticker: t, candidate: c, deep });
+    };
+
+    for (const c of Array.isArray(brief && brief.watch) ? brief.watch : []) add(c, true);
+
+    const screen = new Map();
+    for (const c of Array.isArray(brief && brief.candidates) ? brief.candidates : []) {
+      screen.set(String(c.ticker || "").toUpperCase(), c);
+    }
+
+    for (const raw of s.watchlist || []) {
+      const t = String(raw).toUpperCase();
+      if (byTicker.has(t)) continue;
+      const hit = screen.get(t);
+      byTicker.set(t, { ticker: t, candidate: hit || null, deep: false });
+    }
+
+    return Array.from(byTicker.values());
+  }
+
   function previewLine(s) {
     const bits = [`falls of ${s.dropThreshold}%+ in a day or week`];
     bits.push(`above ${CAPS[s.minMarketCap].short} market cap`);
@@ -281,21 +313,24 @@
     const shown = filterCandidates(brief.candidates, settings);
 
     // The highest-signal event the app can produce: a name he already watches
-    // has taken a real hit.
-    const watchlistHit = (Array.isArray(brief.watch) ? brief.watch : []).find(
-      (c) => typeof c.dropPct === "number" && Math.abs(c.dropPct) >= settings.dropThreshold
-    );
+    // has taken a real hit. Covers both the deep list and anything on his own
+    // phone list that turned up in today's screen.
+    const watched = new Set((settings.watchlist || []).map((t) => String(t).toUpperCase()));
+    const watchlistHit = []
+      .concat(Array.isArray(brief.watch) ? brief.watch : [])
+      .concat(brief.candidates.filter((c) => watched.has(String(c.ticker || "").toUpperCase())))
+      .find((c) => typeof c.dropPct === "number" && Math.abs(c.dropPct) >= settings.dropThreshold);
 
     return { ok: true, brief, shown, settings, watchlistHit: watchlistHit || null };
   }
 
   const BH = {
     STALE_AFTER_MS, SECTORS, CAPS, DISCLAIMER, DEFAULTS,
-    BRIEF_URL, WATCHLIST_EDIT_URL, K_BRIEF,
+    BRIEF_URL, K_BRIEF,
     idbGet, idbSet,
     getSettings, putSettings, getBrief,
     fetchPublished, syncPublished, filterCandidates, previewLine,
-    filterStats, blindSpots,
+    filterStats, blindSpots, watchEntries,
     refreshBrief, BriefError,
   };
 


### PR DESCRIPTION
Follow-on from #25. Five runs cover the five trading sessions, so there is no new brief on Sunday or Monday — Friday's close is still the newest data there is.

The app said "a new brief arrives each morning", which would make that gap read as a failure on a Sunday. The footnote and the Settings explainer now state the real cadence and why the gap exists.

---
_Generated by [Claude Code](https://claude.ai/code/session_014CgzP2epEZapmRFBZ2TBHR)_